### PR TITLE
Fix API base URL for Docker production builds

### DIFF
--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -1,4 +1,6 @@
-const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000';
+// Use relative URLs in production (Docker) so requests go through nginx proxy
+// Use localhost:5000 in development for direct backend access
+const API_BASE_URL = process.env.REACT_APP_API_URL || (process.env.NODE_ENV === 'production' ? '' : 'http://localhost:5000');
 
 // Get CSRF token from cookies
 function getCsrfToken() {


### PR DESCRIPTION
The frontend was trying to connect to localhost:5000 which doesn't work inside Docker containers. Now uses relative URLs in production so requests go through the nginx proxy to the backend server.

- Production (Docker): Uses empty string for API_BASE_URL (relative URLs)
- Development: Uses http://localhost:5000 for direct backend access

This fixes the setup flow not appearing on first run in Docker deployments.