### PR TITLE
Fix CSRF token error and regex pattern in setup form

### DIFF
--- a/client/src/components/Setup.js
+++ b/client/src/components/Setup.js
@@ -90,9 +90,11 @@ function Setup({ onSetup }) {
               required
               minLength={3}
               maxLength={50}
-              pattern="[a-zA-Z0-9_-]+"
               title="Nur Buchstaben, Zahlen, Bindestriche und Unterstriche"
             />
+            <small className="form-hint">
+              Nur Buchstaben, Zahlen, Bindestriche und Unterstriche erlaubt
+            </small>
           </div>
 
           <div className="form-group">

--- a/server/server.js
+++ b/server/server.js
@@ -77,18 +77,17 @@ app.use(limiter); // Rate Limiting anwenden
 // Sicherheit: XSS-Schutz durch Input-Sanitization
 app.use(sanitizeInputMiddleware);
 
-// CSRF-Schutz (nach cookieParser, vor Routen)
+// CSRF-Schutz (nur für Notizen-Routes, nicht für Auth da JWT verwendet wird)
 const csrfProtection = csrf({ cookie: true });
-app.use(csrfProtection);
 
 // CSRF-Token-Endpunkt
-app.get('/api/csrf-token', (req, res) => {
+app.get('/api/csrf-token', csrfProtection, (req, res) => {
   res.json({ csrfToken: req.csrfToken() });
 });
 
 // Routen
-app.use('/api/auth', authRouter);
-app.use('/api/notes', notesRouter);
+app.use('/api/auth', authRouter); // Keine CSRF für Auth (JWT-basiert)
+app.use('/api/notes', csrfProtection, notesRouter); // CSRF für Notizen
 
 // Root-Route
 app.get('/', (req, res) => {


### PR DESCRIPTION
- Removed CSRF protection from /api/auth routes (JWT-based auth doesn't need it)
- CSRF protection now only applies to /api/notes routes
- Removed problematic regex pattern attribute from username input
- Added helper text instead of HTML5 pattern validation

This fixes the "invalid csrf token" error during initial setup.