### PR TITLE
Fix API URL double /api prefix issue

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -63,8 +63,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            REACT_APP_API_URL=/api
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/DOCKER_BUILD.md
+++ b/DOCKER_BUILD.md
@@ -54,12 +54,7 @@ DOCKER_USERNAME=yourusername VERSION=v1.0.0 ./build-allinone.sh
 docker build \
   -f Dockerfile.allinone \
   -t valentin2177/keeplocal:latest \
-  --build-arg REACT_APP_API_URL=/api \
   .
-```
-
-**Build Arguments:**
-- `REACT_APP_API_URL`: API endpoint for the React frontend (default: `/api`)
 
 **Size Optimization:**
 The all-in-one image uses multi-stage builds to minimize size:
@@ -234,7 +229,6 @@ docker buildx build \
   --platform linux/amd64,linux/arm64 \
   -f Dockerfile.allinone \
   -t valentin2177/keeplocal:latest \
-  --build-arg REACT_APP_API_URL=/api \
   --push \
   .
 ```

--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -15,7 +15,8 @@ RUN npm install
 COPY client/ ./
 
 # Build React app with production settings
-ARG REACT_APP_API_URL=/api
+# IMPORTANT: REACT_APP_API_URL must be empty because the client code already adds /api prefix
+ARG REACT_APP_API_URL=
 ENV REACT_APP_API_URL=${REACT_APP_API_URL}
 RUN npm run build
 

--- a/build-allinone.sh
+++ b/build-allinone.sh
@@ -16,15 +16,11 @@ IMAGE_NAME="${IMAGE_NAME:-keeplocal}"
 VERSION="${VERSION:-latest}"
 FULL_IMAGE="${DOCKER_USERNAME}/${IMAGE_NAME}:${VERSION}"
 
-# Optional: Build argument for API URL
-REACT_APP_API_URL="${REACT_APP_API_URL:-/api}"
-
 echo "Build Configuration:"
 echo "  Docker Username: ${DOCKER_USERNAME}"
 echo "  Image Name:      ${IMAGE_NAME}"
 echo "  Version Tag:     ${VERSION}"
 echo "  Full Image:      ${FULL_IMAGE}"
-echo "  API URL:         ${REACT_APP_API_URL}"
 echo ""
 
 # Check if Docker is installed
@@ -47,7 +43,6 @@ echo ""
 docker build \
     -f Dockerfile.allinone \
     -t "${FULL_IMAGE}" \
-    --build-arg REACT_APP_API_URL="${REACT_APP_API_URL}" \
     .
 
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
The React client code already adds /api prefix to all API calls (see client/src/services/api.js), so REACT_APP_API_URL must be empty.

Previously:
- REACT_APP_API_URL was set to /api
- Client code added another /api
- Result: /api/api/auth/login (404 error)

Now:
- REACT_APP_API_URL is empty
- Client code adds /api
- Result: /api/auth/login (correct)

Changes:
- Dockerfile.allinone: Set REACT_APP_API_URL to empty string
- build-allinone.sh: Removed REACT_APP_API_URL build argument
- .github/workflows/docker-build.yml: Removed REACT_APP_API_URL
- DOCKER_BUILD.md: Updated documentation