### PR TITLE
Fix OLED mode: show current theme icon and ensure white text

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -130,6 +130,7 @@ body.oled-mode {
 
 .dark-mode .App-header {
   background: #1e3a5f;
+  color: #ffffff;
 }
 
 .oled-mode .App-header {
@@ -234,6 +235,16 @@ body.oled-mode {
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
+.oled-mode .user-name {
+  background: rgba(255, 255, 255, 0.2);
+  color: #ffffff;
+}
+
+.oled-mode .user-name.clickable:hover {
+  background: rgba(255, 255, 255, 0.3);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+}
+
 .btn-logout {
   padding: 8px 24px;
   background: transparent;
@@ -292,6 +303,21 @@ body.oled-mode {
   background: rgba(255, 255, 255, 0.15);
   border-color: rgba(255, 255, 255, 0.5);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.oled-mode .btn-logout {
+  border-color: rgba(255, 255, 255, 0.4);
+  color: #ffffff;
+}
+
+.oled-mode .btn-logout::before {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.oled-mode .btn-logout:hover {
+  background: rgba(255, 255, 255, 0.2);
+  border-color: rgba(255, 255, 255, 0.6);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
 }
 
 .App-container {
@@ -581,6 +607,14 @@ body.oled-mode {
 
 .dark-mode .mobile-menu-toggle:hover {
   background: rgba(255, 255, 255, 0.15);
+}
+
+.oled-mode .mobile-menu-toggle {
+  color: #ffffff;
+}
+
+.oled-mode .mobile-menu-toggle:hover {
+  background: rgba(255, 255, 255, 0.2);
 }
 
 @media (max-width: 768px) {

--- a/client/src/components/ThemeToggle.js
+++ b/client/src/components/ThemeToggle.js
@@ -7,9 +7,9 @@ function ThemeToggle({ theme, onToggle }) {
 
   // Get icon and title based on current theme
   const getThemeIcon = () => {
-    if (theme === 'light') return '🌙'; // Dark mode next
-    if (theme === 'dark') return '⚫'; // OLED mode next
-    return '☀️'; // Light mode next
+    if (theme === 'light') return '☀️'; // Currently light mode
+    if (theme === 'dark') return '🌙'; // Currently dark mode
+    return '⚫'; // Currently OLED mode
   };
 
   const getThemeTitle = () => {


### PR DESCRIPTION
Icon changes:
- Theme toggle now shows current mode icon instead of next mode
- Light mode: ☀️ (sun)
- Dark mode: 🌙 (moon)
- OLED mode: ⚫ (black dot)

Text color improvements for OLED mode:
- Add explicit white color to header
- Add white text to user name element
- Add white text to logout button
- Add white text to mobile menu toggle
- Ensure all text has proper contrast on pure black background

All text elements now have rgba(255, 255, 255, 0.95) or #ffffff color in OLED mode for maximum contrast and readability.