### PR TITLE
Fix sidebar to scroll independently from notes area

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -322,7 +322,8 @@ body.oled-mode {
 
 .App-container {
   display: flex;
-  min-height: calc(100vh - 60px);
+  height: calc(100vh - 60px);
+  overflow: hidden;
 }
 
 .App-main {
@@ -331,6 +332,8 @@ body.oled-mode {
   margin: 0 auto;
   padding: 24px 16px;
   width: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .loading {

--- a/client/src/components/Sidebar.css
+++ b/client/src/components/Sidebar.css
@@ -1,12 +1,12 @@
 .sidebar {
   width: 240px;
   background: transparent;
-  height: calc(100vh - 60px);
-  position: sticky;
-  top: 60px;
+  height: 100%;
   overflow-y: auto;
+  overflow-x: hidden;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   border-right: 1px solid rgba(0, 0, 0, 0.08);
+  flex-shrink: 0;
 }
 
 .dark-mode .sidebar {


### PR DESCRIPTION
- Change App-container from min-height to fixed height to prevent whole page scroll
- Add overflow-y: auto to App-main so notes area scrolls independently
- Update sidebar to use height: 100% instead of position: sticky
- Both sidebar and notes area now have independent scroll containers