### PR TITLE
Add overflow hidden to index.css for maximum compatibility

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -4,6 +4,11 @@
   box-sizing: border-box;
 }
 
+html, body, #root {
+  height: 100%;
+  overflow: hidden;
+}
+
 :root {
   --bg-primary: #f5f5f5;
   --bg-secondary: #ffffff;


### PR DESCRIPTION
- Ensure html, body, #root have overflow: hidden in index.css
- This guarantees the styles are applied early in CSS cascade
- Prevents any page-level scrolling