### PR TITLE
Fix archive/collaborate buttons and add them to NoteModal

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -630,6 +630,8 @@ function AppContent() {
           note={noteModal.note}
           onSave={handleModalSave}
           onClose={closeNoteModal}
+          onToggleArchive={toggleArchiveNote}
+          onOpenCollaborate={openCollaborateModal}
         />
       )}
 

--- a/client/src/components/NoteList.js
+++ b/client/src/components/NoteList.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Note from './Note';
 import './NoteList.css';
 
-function NoteList({ notes, onDeleteNote, onUpdateNote, onTogglePin, onOpenModal, onDragStart, onDragEnd, onDragOver, onDrop, operationLoading }) {
+function NoteList({ notes, onDeleteNote, onUpdateNote, onTogglePin, onToggleArchive, onOpenCollaborate, onOpenModal, onDragStart, onDragEnd, onDragOver, onDrop, operationLoading }) {
   return (
     <div className="note-list">
       {notes.map((note) => (
@@ -12,6 +12,8 @@ function NoteList({ notes, onDeleteNote, onUpdateNote, onTogglePin, onOpenModal,
           onDelete={onDeleteNote}
           onUpdate={onUpdateNote}
           onTogglePin={onTogglePin}
+          onToggleArchive={onToggleArchive}
+          onOpenCollaborate={onOpenCollaborate}
           onOpenModal={onOpenModal}
           onDragStart={onDragStart}
           onDragEnd={onDragEnd}

--- a/client/src/components/NoteModal.css
+++ b/client/src/components/NoteModal.css
@@ -278,6 +278,75 @@
   background: rgba(26, 115, 232, 0.2);
 }
 
+.btn-modal-archive,
+.btn-modal-collaborate {
+  background: transparent;
+  border: none;
+  padding: 8px;
+  border-radius: 50%;
+  cursor: pointer;
+  color: rgba(0, 0, 0, 0.71);
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.btn-modal-archive:hover,
+.btn-modal-collaborate:hover {
+  background: rgba(95, 99, 104, 0.157);
+}
+
+.btn-modal-archive:active,
+.btn-modal-collaborate:active {
+  background: rgba(95, 99, 104, 0.22);
+}
+
+.btn-modal-archive.archived {
+  background: rgba(251, 188, 4, 0.1);
+  color: #f57f17;
+}
+
+.dark-mode .btn-modal-archive,
+.dark-mode .btn-modal-collaborate {
+  color: rgba(255, 255, 255, 0.87);
+}
+
+.dark-mode .btn-modal-archive:hover,
+.dark-mode .btn-modal-collaborate:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.dark-mode .btn-modal-archive:active,
+.dark-mode .btn-modal-collaborate:active {
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.dark-mode .btn-modal-archive.archived {
+  background: rgba(251, 188, 4, 0.2);
+  color: #fbc02d;
+}
+
+.oled-mode .btn-modal-archive,
+.oled-mode .btn-modal-collaborate {
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.oled-mode .btn-modal-archive:hover,
+.oled-mode .btn-modal-collaborate:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.oled-mode .btn-modal-archive:active,
+.oled-mode .btn-modal-collaborate:active {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.oled-mode .btn-modal-archive.archived {
+  background: rgba(251, 188, 4, 0.25);
+  color: #fdd835;
+}
+
 .todo-list-container {
   flex: 1;
   display: flex;

--- a/client/src/components/NoteModal.js
+++ b/client/src/components/NoteModal.js
@@ -7,7 +7,7 @@ import { sanitize } from '../utils/sanitize';
 import { getColorVar } from '../utils/colorMapper';
 import { fetchLinkPreviewAPI } from '../services/api';
 
-function NoteModal({ note, onSave, onClose }) {
+function NoteModal({ note, onSave, onClose, onToggleArchive, onOpenCollaborate }) {
   const { t } = useLanguage();
   const [title, setTitle] = useState(note?.title || '');
   const [content, setContent] = useState(note?.content || '');
@@ -313,6 +313,43 @@ function NoteModal({ note, onSave, onClose }) {
                 <path d="M9 11l3 3 6-6"/>
               </svg>
             </button>
+            {note && onToggleArchive && (
+              <button
+                type="button"
+                className={`btn-modal-archive ${note.isArchived ? 'archived' : ''}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggleArchive(note._id);
+                  onClose();
+                }}
+                title={note.isArchived ? "Dearchivieren" : "Archivieren"}
+                aria-label={note.isArchived ? "Dearchivieren" : "Archivieren"}
+              >
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M21 8v13H3V8M1 3h22v5H1zM10 12h4"/>
+                </svg>
+              </button>
+            )}
+            {note && onOpenCollaborate && (
+              <button
+                type="button"
+                className="btn-modal-collaborate"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onOpenCollaborate(note);
+                  onClose();
+                }}
+                title="Teilen"
+                aria-label="Teilen"
+              >
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
+                  <circle cx="9" cy="7" r="4"/>
+                  <path d="M23 21v-2a4 4 0 0 0-3-3.87"/>
+                  <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
+                </svg>
+              </button>
+            )}
           </div>
           <div className="note-modal-actions">
             <button


### PR DESCRIPTION
- Pass onToggleArchive and onOpenCollaborate props through NoteList to Note
- Add archive and collaborate buttons to NoteModal toolbar
- Add CSS styles for btn-modal-archive and btn-modal-collaborate
- Pass archive/collaborate handlers from App.js to NoteModal
- Buttons now appear both in note cards and in the modal
- Fixed "o is not a function" error by properly passing props

This resolves the TypeError and adds the requested functionality to make archive and share buttons visible in the modal popup.