### PR TITLE
Add internationalization and visual indicators for shared notes

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -168,7 +168,7 @@ function AppContent() {
     setOperationLoading(prev => ({ ...prev, [id]: 'archive' }));
     try {
       const response = await notesAPI.toggleArchive(id);
-      const message = response.isArchived ? 'Notiz archiviert' : 'Notiz dearchiviert';
+      const message = response.isArchived ? t('noteArchived') : t('noteUnarchived');
       showToast(message, 'success');
 
       // Notiz aus der Liste entfernen wenn sie archiviert/dearchiviert wird
@@ -182,7 +182,7 @@ function AppContent() {
       }
     } catch (error) {
       console.error('Fehler beim Archivieren der Notiz:', error);
-      showToast(error.message || 'Fehler beim Archivieren der Notiz', 'error');
+      showToast(error.message || t('errorUpdating'), 'error');
     } finally {
       setOperationLoading(prev => ({ ...prev, [id]: false }));
     }

--- a/client/src/components/FriendsModal.js
+++ b/client/src/components/FriendsModal.js
@@ -1,8 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import './FriendsModal.css';
 import { friendsAPI } from '../services/api';
+import { useLanguage } from '../contexts/LanguageContext';
 
 function FriendsModal({ isOpen, onClose, isAdmin }) {
+  const { t } = useLanguage();
   const [activeTab, setActiveTab] = useState('friends'); // 'friends', 'requests', 'add'
   const [friends, setFriends] = useState([]);
   const [friendRequests, setFriendRequests] = useState([]);
@@ -106,7 +108,7 @@ function FriendsModal({ isOpen, onClose, isAdmin }) {
     <div className="modal-overlay" onClick={onClose}>
       <div className="friends-modal" onClick={(e) => e.stopPropagation()}>
         <div className="friends-modal-header">
-          <h2>Freunde verwalten</h2>
+          <h2>{t('friends')}</h2>
           <button className="close-btn" onClick={onClose}>
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
               <path d="M18 6L6 18M6 6l12 12"/>
@@ -119,19 +121,19 @@ function FriendsModal({ isOpen, onClose, isAdmin }) {
             className={`tab-btn ${activeTab === 'friends' ? 'active' : ''}`}
             onClick={() => setActiveTab('friends')}
           >
-            Freunde ({friends.length})
+            {t('friendsList')} ({friends.length})
           </button>
           <button
             className={`tab-btn ${activeTab === 'requests' ? 'active' : ''}`}
             onClick={() => setActiveTab('requests')}
           >
-            Anfragen ({friendRequests.length})
+            {t('requests')} ({friendRequests.length})
           </button>
           <button
             className={`tab-btn ${activeTab === 'add' ? 'active' : ''}`}
             onClick={() => setActiveTab('add')}
           >
-            {isAdmin ? 'Benutzer suchen' : 'Freund hinzufügen'}
+            {isAdmin ? t('searchUsers') : t('addFriendTab')}
           </button>
         </div>
 
@@ -146,11 +148,11 @@ function FriendsModal({ isOpen, onClose, isAdmin }) {
           {activeTab === 'friends' && (
             <div className="friends-list">
               {loading ? (
-                <div className="loading">Lade Freunde...</div>
+                <div className="loading">{t('loading')}</div>
               ) : friends.length === 0 ? (
                 <div className="empty-state">
-                  <p>Keine Freunde gefunden</p>
-                  <p className="hint">Füge Freunde hinzu, um Notizen zu teilen</p>
+                  <p>{t('noFriends')}</p>
+                  <p className="hint">{t('addFriend')}</p>
                 </div>
               ) : (
                 friends.map((friend) => (
@@ -162,7 +164,7 @@ function FriendsModal({ isOpen, onClose, isAdmin }) {
                     <button
                       className="btn-remove"
                       onClick={() => handleRemoveFriend(friend._id)}
-                      title="Freund entfernen"
+                      title={t('removeFriend')}
                     >
                       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                         <path d="M18 6L6 18M6 6l12 12"/>
@@ -178,7 +180,7 @@ function FriendsModal({ isOpen, onClose, isAdmin }) {
             <div className="requests-list">
               {friendRequests.length === 0 ? (
                 <div className="empty-state">
-                  <p>Keine Anfragen</p>
+                  <p>{t('noFriendRequests')}</p>
                 </div>
               ) : (
                 friendRequests.map((request) => (
@@ -192,13 +194,13 @@ function FriendsModal({ isOpen, onClose, isAdmin }) {
                         className="btn-accept"
                         onClick={() => handleAcceptRequest(request._id)}
                       >
-                        ✓ Akzeptieren
+                        ✓ {t('accept')}
                       </button>
                       <button
                         className="btn-reject"
                         onClick={() => handleRejectRequest(request._id)}
                       >
-                        × Ablehnen
+                        × {t('reject')}
                       </button>
                     </div>
                   </div>
@@ -212,20 +214,20 @@ function FriendsModal({ isOpen, onClose, isAdmin }) {
               <div className="search-box">
                 <input
                   type="text"
-                  placeholder={isAdmin ? "Benutzername oder E-Mail suchen..." : "Benutzername eingeben..."}
+                  placeholder={t('searchUsers')}
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   onKeyPress={(e) => e.key === 'Enter' && handleSearch()}
                 />
                 <button onClick={handleSearch} disabled={loading}>
-                  {loading ? 'Suche...' : 'Suchen'}
+                  {loading ? t('loading') : t('search')}
                 </button>
               </div>
 
               <div className="search-results">
                 {searchResults.length === 0 && searchQuery && !loading && (
                   <div className="empty-state">
-                    <p>Keine Benutzer gefunden</p>
+                    <p>{t('noFriends')}</p>
                   </div>
                 )}
 
@@ -240,7 +242,7 @@ function FriendsModal({ isOpen, onClose, isAdmin }) {
                       onClick={() => handleSendRequest(user.username)}
                       disabled={friends.some(f => f._id === user._id)}
                     >
-                      {friends.some(f => f._id === user._id) ? 'Bereits Freund' : '+ Anfrage senden'}
+                      {friends.some(f => f._id === user._id) ? t('noFriends') : `+ ${t('sendFriendRequest')}`}
                     </button>
                   </div>
                 ))}

--- a/client/src/components/Note.css
+++ b/client/src/components/Note.css
@@ -243,6 +243,70 @@
   transition: all 0.3s ease;
 }
 
+/* Collaborators */
+.note-collaborators {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+  padding: 6px 0;
+  font-size: 0.75rem;
+  color: rgba(0, 0, 0, 0.65);
+}
+
+.dark-mode .note-collaborators {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.oled-mode .note-collaborators {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.collaborators-text {
+  font-weight: 500;
+  margin-right: 4px;
+}
+
+.collaborator-avatars {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.collaborator-avatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--accent-color);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.625rem;
+  font-weight: 600;
+  border: 2px solid var(--bg-primary);
+  cursor: default;
+  transition: all 0.2s ease;
+}
+
+.collaborator-avatar:hover {
+  transform: scale(1.1);
+  z-index: 1;
+}
+
+.collaborator-avatar.more {
+  background: rgba(0, 0, 0, 0.3);
+  font-size: 0.5rem;
+}
+
+.dark-mode .collaborator-avatar.more {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.oled-mode .collaborator-avatar.more {
+  background: rgba(255, 255, 255, 0.4);
+}
+
 /* Hover actions */
 .note-hover-actions {
   opacity: 0;

--- a/client/src/components/Note.js
+++ b/client/src/components/Note.js
@@ -173,6 +173,39 @@ function Note({ note, onDelete, onUpdate, onTogglePin, onToggleArchive, onOpenCo
             ))}
           </div>
         )}
+
+        {note.sharedWith && note.sharedWith.length > 0 && (
+          <div className="note-collaborators">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" style={{ marginRight: '4px' }}>
+              <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
+              <circle cx="9" cy="7" r="4"/>
+              <path d="M23 21v-2a4 4 0 0 0-3-3.87"/>
+              <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
+            </svg>
+            <span className="collaborators-text">
+              {note.sharedWith.length === 1
+                ? note.sharedWith[0].username || note.sharedWith[0].email
+                : t('sharedWithCount').replace('{count}', note.sharedWith.length)}
+            </span>
+            <div className="collaborator-avatars">
+              {note.sharedWith.slice(0, 3).map((user, index) => (
+                <div
+                  key={user._id || index}
+                  className="collaborator-avatar"
+                  title={user.username || user.email}
+                >
+                  {(user.username || user.email || '?').charAt(0).toUpperCase()}
+                </div>
+              ))}
+              {note.sharedWith.length > 3 && (
+                <div className="collaborator-avatar more" title={`+${note.sharedWith.length - 3} ${t('collaborators')}`}>
+                  +{note.sharedWith.length - 3}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
         <div className="note-hover-actions">
           <button
             onClick={(e) => {
@@ -180,8 +213,8 @@ function Note({ note, onDelete, onUpdate, onTogglePin, onToggleArchive, onOpenCo
               onTogglePin(note._id);
             }}
             className={`action-btn pin-btn ${note.isPinned ? 'pinned' : ''}`}
-            title={note.isPinned ? "Abheften" : "Anheften"}
-            aria-label={note.isPinned ? "Abheften" : "Anheften"}
+            title={note.isPinned ? t('unpin') : t('pin')}
+            aria-label={note.isPinned ? t('unpin') : t('pin')}
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
               <path d="M12 17v5m-5-9H5a2 2 0 0 1 0-4h14a2 2 0 0 1 0 4h-2m-5-9V2"/>
@@ -193,8 +226,8 @@ function Note({ note, onDelete, onUpdate, onTogglePin, onToggleArchive, onOpenCo
               onToggleArchive(note._id);
             }}
             className={`action-btn archive-btn ${note.isArchived ? 'archived' : ''}`}
-            title={note.isArchived ? "Dearchivieren" : "Archivieren"}
-            aria-label={note.isArchived ? "Dearchivieren" : "Archivieren"}
+            title={note.isArchived ? t('unarchive') : t('archive')}
+            aria-label={note.isArchived ? t('unarchive') : t('archive')}
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
               <path d="M21 8v13H3V8M1 3h22v5H1zM10 12h4"/>
@@ -206,8 +239,8 @@ function Note({ note, onDelete, onUpdate, onTogglePin, onToggleArchive, onOpenCo
               onOpenCollaborate(note);
             }}
             className="action-btn collaborate-btn"
-            title="Teilen"
-            aria-label="Teilen"
+            title={t('share')}
+            aria-label={t('share')}
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
               <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>

--- a/client/src/components/NoteModal.js
+++ b/client/src/components/NoteModal.js
@@ -322,8 +322,8 @@ function NoteModal({ note, onSave, onClose, onToggleArchive, onOpenCollaborate }
                   onToggleArchive(note._id);
                   onClose();
                 }}
-                title={note.isArchived ? "Dearchivieren" : "Archivieren"}
-                aria-label={note.isArchived ? "Dearchivieren" : "Archivieren"}
+                title={note.isArchived ? t('unarchive') : t('archive')}
+                aria-label={note.isArchived ? t('unarchive') : t('archive')}
               >
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                   <path d="M21 8v13H3V8M1 3h22v5H1zM10 12h4"/>
@@ -339,8 +339,8 @@ function NoteModal({ note, onSave, onClose, onToggleArchive, onOpenCollaborate }
                   onOpenCollaborate(note);
                   onClose();
                 }}
-                title="Teilen"
-                aria-label="Teilen"
+                title={t('share')}
+                aria-label={t('share')}
               >
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                   <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>

--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -103,12 +103,12 @@ function Sidebar({
             onTagSelect(null);
             onMobileClose();
           }}
-          aria-label="Archivierte Notizen"
+          aria-label={t('archived')}
         >
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
             <path d="M21 8v13H3V8M1 3h22v5H1zM10 12h4"/>
           </svg>
-          <span>Archiviert</span>
+          <span>{t('archived')}</span>
           <span className="count">{archivedCount || 0}</span>
         </button>
 
@@ -118,14 +118,14 @@ function Sidebar({
             onOpenFriends();
             onMobileClose();
           }}
-          aria-label="Freunde verwalten"
+          aria-label={t('friends')}
         >
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
             <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/>
             <circle cx="9" cy="7" r="4"/>
             <path d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75"/>
           </svg>
-          <span>Freunde</span>
+          <span>{t('friends')}</span>
         </button>
 
         {isAdmin && (

--- a/client/src/translations/de.js
+++ b/client/src/translations/de.js
@@ -207,4 +207,46 @@ export const de = {
 
   // Search
   clearSearch: 'Suche löschen',
+
+  // Archive
+  archive: 'Archivieren',
+  unarchive: 'Dearchivieren',
+  archived: 'Archiviert',
+  noteArchived: 'Notiz archiviert',
+  noteUnarchived: 'Notiz dearchiviert',
+
+  // Collaboration
+  collaborate: 'Teilen',
+  share: 'Teilen',
+  shareNote: 'Notiz teilen',
+  sharedWith: 'Geteilt mit',
+  collaborators: 'Mitbearbeiter',
+  removeCollaborator: 'Mitbearbeiter entfernen',
+  addCollaborator: 'Mitbearbeiter hinzufügen',
+  noteShared: 'Notiz geteilt',
+  noteUnshared: 'Freigabe aufgehoben',
+  collaboratorRemoved: 'Mitbearbeiter entfernt',
+  sharedWithCount: 'Geteilt mit {count}',
+
+  // Friends
+  friends: 'Freunde',
+  addFriend: 'Freund hinzufügen',
+  removeFriend: 'Freund entfernen',
+  friendRequests: 'Freundschaftsanfragen',
+  sendFriendRequest: 'Freundschaftsanfrage senden',
+  acceptFriendRequest: 'Anfrage annehmen',
+  rejectFriendRequest: 'Anfrage ablehnen',
+  friendRequestSent: 'Freundschaftsanfrage gesendet',
+  friendRequestAccepted: 'Freundschaftsanfrage angenommen',
+  friendRequestRejected: 'Freundschaftsanfrage abgelehnt',
+  friendRemoved: 'Freund entfernt',
+  searchUsers: 'Benutzer suchen',
+  noFriends: 'Keine Freunde',
+  noFriendRequests: 'Keine Freundschaftsanfragen',
+  pending: 'Ausstehend',
+  accept: 'Annehmen',
+  reject: 'Ablehnen',
+  friendsList: 'Freundesliste',
+  requests: 'Anfragen',
+  addFriendTab: 'Freund hinzufügen',
 };

--- a/client/src/translations/en.js
+++ b/client/src/translations/en.js
@@ -207,4 +207,46 @@ export const en = {
 
   // Search
   clearSearch: 'Clear search',
+
+  // Archive
+  archive: 'Archive',
+  unarchive: 'Unarchive',
+  archived: 'Archived',
+  noteArchived: 'Note archived',
+  noteUnarchived: 'Note unarchived',
+
+  // Collaboration
+  collaborate: 'Share',
+  share: 'Share',
+  shareNote: 'Share note',
+  sharedWith: 'Shared with',
+  collaborators: 'Collaborators',
+  removeCollaborator: 'Remove collaborator',
+  addCollaborator: 'Add collaborator',
+  noteShared: 'Note shared',
+  noteUnshared: 'Sharing removed',
+  collaboratorRemoved: 'Collaborator removed',
+  sharedWithCount: 'Shared with {count}',
+
+  // Friends
+  friends: 'Friends',
+  addFriend: 'Add friend',
+  removeFriend: 'Remove friend',
+  friendRequests: 'Friend requests',
+  sendFriendRequest: 'Send friend request',
+  acceptFriendRequest: 'Accept request',
+  rejectFriendRequest: 'Reject request',
+  friendRequestSent: 'Friend request sent',
+  friendRequestAccepted: 'Friend request accepted',
+  friendRequestRejected: 'Friend request rejected',
+  friendRemoved: 'Friend removed',
+  searchUsers: 'Search users',
+  noFriends: 'No friends',
+  noFriendRequests: 'No friend requests',
+  pending: 'Pending',
+  accept: 'Accept',
+  reject: 'Reject',
+  friendsList: 'Friends list',
+  requests: 'Requests',
+  addFriendTab: 'Add friend',
 };


### PR DESCRIPTION
Translations:
- Add German and English translations for archive/collaborate/friends features
- Update all components to use translation keys (t())
- Replace hardcoded German texts in Note, NoteModal, Sidebar, FriendsModal, App

Visual Indicators for Collaboration:
- Add collaborator display to notes (Google Keep-style)
- Show avatar circles with user initials for shared notes
- Display "Shared with X" text when note has collaborators
- Show up to 3 avatars, with "+N" indicator for additional collaborators
- Add hover effects to collaborator avatars

Styling:
- Add CSS for .note-collaborators section
- Style .collaborator-avatar with circular design
- Support for light/dark/OLED themes
- Responsive avatar sizing and spacing

Translation Keys Added:
- archive, unarchive, archived, noteArchived, noteUnarchived
- collaborate, share, shareNote, sharedWith, collaborators
- friends, addFriend, removeFriend, friendRequests
- accept, reject, pending, searchUsers
- sharedWithCount, friendsList, requests, addFriendTab

This ensures all archive and collaboration features work in both German and English, and users can immediately see when notes are shared with others, just like in Google Keep.