### PR TITLE
Add image upload functionality to notes

### DIFF
--- a/client/src/components/Note.css
+++ b/client/src/components/Note.css
@@ -125,6 +125,59 @@
   margin-top: 0.75rem;
 }
 
+/* Note images display */
+.note-images {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 6px;
+  margin-top: 12px;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.note-images.single {
+  grid-template-columns: 1fr;
+}
+
+.note-image-preview {
+  position: relative;
+  aspect-ratio: 1;
+  overflow: hidden;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.note-image-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.2s ease;
+}
+
+.note-image-preview:hover img {
+  transform: scale(1.05);
+}
+
+.note-images-more {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.7);
+  color: white;
+  padding: 4px 8px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: 6px 0 0 0;
+}
+
+.dark-mode .note-image-preview {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.oled-mode .note-image-preview {
+  background: rgba(255, 255, 255, 0.08);
+}
+
 .note-link {
   color: var(--accent-color);
   text-decoration: none;

--- a/client/src/components/Note.js
+++ b/client/src/components/Note.js
@@ -164,6 +164,21 @@ function Note({ note, onDelete, onUpdate, onTogglePin, onToggleArchive, onOpenCo
           </>
         )}
 
+        {note.images && note.images.length > 0 && (
+          <div className="note-images">
+            {note.images.slice(0, 4).map((image, index) => (
+              <div key={index} className="note-image-preview">
+                <img src={image.url} alt={image.filename} />
+              </div>
+            ))}
+            {note.images.length > 4 && (
+              <div className="note-images-more">
+                +{note.images.length - 4}
+              </div>
+            )}
+          </div>
+        )}
+
         {note.tags && note.tags.length > 0 && (
           <div className="note-tags">
             {note.tags.map((tag, index) => (

--- a/client/src/components/NoteModal.css
+++ b/client/src/components/NoteModal.css
@@ -620,6 +620,166 @@
   margin-top: 0.75rem;
 }
 
+/* Image upload styles */
+.note-modal-images {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.uploaded-images,
+.new-images-preview {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.image-preview {
+  position: relative;
+  aspect-ratio: 1;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 2px solid rgba(0, 0, 0, 0.1);
+  transition: all 0.2s ease;
+}
+
+.image-preview:hover {
+  border-color: var(--accent-color);
+  transform: scale(1.02);
+}
+
+.image-preview.new {
+  border-color: var(--accent-color);
+  border-style: dashed;
+}
+
+.image-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.image-delete-btn {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background: rgba(0, 0, 0, 0.7);
+  border: none;
+  padding: 4px;
+  border-radius: 50%;
+  cursor: pointer;
+  color: white;
+  opacity: 0;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.image-preview:hover .image-delete-btn {
+  opacity: 1;
+}
+
+.image-delete-btn:hover {
+  background: #d32f2f;
+  transform: scale(1.1);
+}
+
+.new-badge {
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  background: var(--accent-color);
+  color: white;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.image-upload-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.btn-select-images {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  background: transparent;
+  border: 2px solid var(--border-color);
+  border-radius: 8px;
+  color: var(--text-primary);
+  font-size: 0.938rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+}
+
+.btn-select-images:hover {
+  background: rgba(0, 0, 0, 0.05);
+  border-color: var(--accent-color);
+  color: var(--accent-color);
+}
+
+.btn-upload-images {
+  padding: 0.75rem 1.25rem;
+  background: var(--accent-color);
+  border: none;
+  border-radius: 8px;
+  color: white;
+  font-size: 0.938rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+}
+
+.btn-upload-images:hover:not(:disabled) {
+  background: var(--accent-hover);
+  transform: translateY(-1px);
+}
+
+.btn-upload-images:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Dark mode image upload */
+.dark-mode .image-preview {
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.dark-mode .image-preview:hover {
+  border-color: #8ab4f8;
+}
+
+.dark-mode .btn-select-images:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: #8ab4f8;
+  color: #8ab4f8;
+}
+
+/* OLED mode image upload */
+.oled-mode .image-preview {
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.oled-mode .image-preview:hover {
+  border-color: #8ab4f8;
+}
+
+.oled-mode .btn-select-images:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: #8ab4f8;
+  color: #8ab4f8;
+}
+
 @media (max-width: 768px) {
   .note-modal {
     max-width: 100%;

--- a/client/src/services/api/notesAPI.js
+++ b/client/src/services/api/notesAPI.js
@@ -109,6 +109,50 @@ const notesAPI = {
       method: 'POST',
       body: JSON.stringify({ url }),
     }),
+
+  /**
+   * Upload images to a note
+   * @param {string} id - Note ID
+   * @param {FileList|Array} files - Files to upload
+   * @returns {Promise<Object>} Updated note with images
+   */
+  uploadImages: async (id, files) => {
+    const formData = new FormData();
+    Array.from(files).forEach((file) => formData.append('images', file));
+
+    // Manual fetch for multipart/form-data (don't set Content-Type, browser will set it with boundary)
+    const token = localStorage.getItem('token');
+    const csrfToken = sessionStorage.getItem('csrfToken') || localStorage.getItem('csrfToken');
+
+    const headers = {};
+    if (token) headers['Authorization'] = `Bearer ${token}`;
+    if (csrfToken) headers['X-CSRF-Token'] = csrfToken;
+
+    const response = await fetch(`${API_ENDPOINTS.NOTES.BY_ID(id)}/images`, {
+      method: 'POST',
+      headers,
+      body: formData,
+      credentials: 'include',
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.error || 'Bild-Upload fehlgeschlagen');
+    }
+
+    return response.json();
+  },
+
+  /**
+   * Delete an image from a note
+   * @param {string} id - Note ID
+   * @param {string} filename - Image filename to delete
+   * @returns {Promise<Object>} Updated note without the image
+   */
+  deleteImage: (id, filename) =>
+    fetchWithAuth(`${API_ENDPOINTS.NOTES.BY_ID(id)}/images/${filename}`, {
+      method: 'DELETE',
+    }),
 };
 
 export default notesAPI;

--- a/server/middleware/upload.js
+++ b/server/middleware/upload.js
@@ -1,0 +1,54 @@
+/**
+ * File Upload Middleware
+ * Handles image uploads using multer
+ */
+
+const multer = require('multer');
+const path = require('path');
+const fs = require('fs');
+
+// Ensure upload directory exists
+const uploadDir = path.join(__dirname, '../uploads/images');
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir, { recursive: true });
+}
+
+// Configure storage
+const storage = multer.diskStorage({
+  destination: function (req, file, cb) {
+    cb(null, uploadDir);
+  },
+  filename: function (req, file, cb) {
+    // Generate unique filename: timestamp-randomstring-originalname
+    const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1E9);
+    const ext = path.extname(file.originalname);
+    const nameWithoutExt = path.basename(file.originalname, ext);
+    // Sanitize filename
+    const sanitizedName = nameWithoutExt.replace(/[^a-zA-Z0-9]/g, '_');
+    cb(null, sanitizedName + '-' + uniqueSuffix + ext);
+  }
+});
+
+// File filter - only allow images
+const fileFilter = (req, file, cb) => {
+  const allowedTypes = /jpeg|jpg|png|gif|webp/;
+  const extname = allowedTypes.test(path.extname(file.originalname).toLowerCase());
+  const mimetype = allowedTypes.test(file.mimetype);
+
+  if (mimetype && extname) {
+    return cb(null, true);
+  } else {
+    cb(new Error('Nur Bilder sind erlaubt (jpeg, jpg, png, gif, webp)'));
+  }
+};
+
+// Create multer instance
+const upload = multer({
+  storage: storage,
+  limits: {
+    fileSize: 5 * 1024 * 1024, // 5MB max file size
+  },
+  fileFilter: fileFilter
+});
+
+module.exports = upload;

--- a/server/package.json
+++ b/server/package.json
@@ -7,26 +7,31 @@
     "start": "node server.js",
     "dev": "nodemon server.js"
   },
-  "keywords": ["notes", "keep", "express"],
+  "keywords": [
+    "notes",
+    "keep",
+    "express"
+  ],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.18.2",
-    "cors": "^2.8.5",
+    "bcryptjs": "^2.4.3",
     "body-parser": "^1.20.2",
-    "uuid": "^9.0.1",
-    "mongoose": "^8.0.0",
+    "compression": "^1.7.4",
+    "cookie-parser": "^1.4.6",
+    "cors": "^2.8.5",
+    "csurf": "^1.11.0",
     "dotenv": "^16.3.1",
-    "xss": "^1.0.14",
+    "express": "^4.18.2",
+    "express-rate-limit": "^7.1.5",
+    "express-session": "^1.17.3",
     "express-validator": "^7.0.1",
     "helmet": "^7.1.0",
-    "express-rate-limit": "^7.1.5",
-    "csurf": "^1.11.0",
-    "cookie-parser": "^1.4.6",
-    "express-session": "^1.17.3",
-    "compression": "^1.7.4",
     "jsonwebtoken": "^9.0.2",
-    "bcryptjs": "^2.4.3"
+    "mongoose": "^8.0.0",
+    "multer": "^1.4.5-lts.1",
+    "uuid": "^9.0.1",
+    "xss": "^1.0.14"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/server/server.js
+++ b/server/server.js
@@ -7,6 +7,7 @@ const rateLimit = require('express-rate-limit');
 const compression = require('compression');
 const cookieParser = require('cookie-parser');
 const csrf = require('csurf');
+const path = require('path');
 const connectDB = require('./config/database');
 const notesRouter = require('./routes/notes');
 const authRouter = require('./routes/auth');
@@ -94,6 +95,9 @@ app.use(limiter); // Rate Limiting anwenden
 
 // Sicherheit: XSS-Schutz durch Input-Sanitization
 app.use(sanitizeInputMiddleware);
+
+// Static file serving for uploaded images
+app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 
 // CSRF-Schutz (nach cookieParser, vor Routen)
 // Auth-Routen sind ausgenommen, da sie keine CSRF-Token benötigen

--- a/server/services/notesService.js
+++ b/server/services/notesService.js
@@ -299,6 +299,70 @@ async function unshareNote(noteId, userId, targetUserId) {
   return note;
 }
 
+/**
+ * Add images to a note
+ * @param {string} noteId - Note ID
+ * @param {string} userId - Owner user ID
+ * @param {Array} imageData - Array of image objects {url, filename, uploadedAt}
+ * @returns {Promise<Object>} Updated note
+ */
+async function addImages(noteId, userId, imageData) {
+  const note = await Note.findOneAndUpdate(
+    {
+      _id: noteId,
+      userId: userId
+    },
+    {
+      $push: { images: { $each: imageData } }
+    },
+    {
+      new: true,
+      runValidators: true
+    }
+  ).populate('userId', 'username email')
+    .populate('sharedWith', 'username email');
+
+  if (!note) {
+    const error = new Error(errorMessages.NOTES.NOT_FOUND);
+    error.statusCode = 404;
+    throw error;
+  }
+
+  return note;
+}
+
+/**
+ * Remove an image from a note
+ * @param {string} noteId - Note ID
+ * @param {string} userId - Owner user ID
+ * @param {string} filename - Image filename to remove
+ * @returns {Promise<Object>} Updated note
+ */
+async function removeImage(noteId, userId, filename) {
+  const note = await Note.findOneAndUpdate(
+    {
+      _id: noteId,
+      userId: userId
+    },
+    {
+      $pull: { images: { filename: filename } }
+    },
+    {
+      new: true,
+      runValidators: true
+    }
+  ).populate('userId', 'username email')
+    .populate('sharedWith', 'username email');
+
+  if (!note) {
+    const error = new Error(errorMessages.NOTES.NOT_FOUND);
+    error.statusCode = 404;
+    throw error;
+  }
+
+  return note;
+}
+
 module.exports = {
   getAllNotes,
   getNoteById,
@@ -309,5 +373,7 @@ module.exports = {
   toggleArchiveNote,
   shareNote,
   unshareNote,
+  addImages,
+  removeImage,
   buildNotesQuery, // Export for testing
 };


### PR DESCRIPTION
Features:
- Backend: Multer integration for handling multipart/form-data uploads
- Upload middleware with file validation (5MB limit, image types only)
- API routes: POST /:id/images and DELETE /:id/images/:filename
- Service methods for adding/removing images using atomic MongoDB operations
- Static file serving for uploaded images at /uploads

Frontend:
- Image upload UI in NoteModal with file selection and preview
- Display uploaded images in Note component (grid layout, max 4 shown)
- Image deletion functionality with confirmation
- Responsive styling with dark/OLED mode support
- Visual feedback for new images before upload

Technical improvements:
- Atomic $push with $each for adding images
- Atomic $pull for removing images
- Automatic cleanup of uploaded files on error
- FormData API for client-side multipart uploads
- CSRF token handling in multipart requests