### PR TITLE
Fix modal scrolling and limit dashboard note length

### DIFF
--- a/client/src/components/Note.css
+++ b/client/src/components/Note.css
@@ -74,6 +74,11 @@
   word-wrap: break-word;
   font-family: 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   transition: color 0.3s ease;
+  display: -webkit-box;
+  -webkit-line-clamp: 6;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  max-height: 9em;
 }
 
 .note-todo-list {
@@ -82,6 +87,20 @@
   gap: 0.5rem;
   margin: 0;
   padding: 0;
+  max-height: 9em;
+  overflow: hidden;
+  position: relative;
+}
+
+.note-todo-list::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 2em;
+  background: linear-gradient(to bottom, transparent, var(--bg-primary));
+  pointer-events: none;
 }
 
 .note-todo-item {
@@ -119,6 +138,10 @@
 
 .dark-mode .note-todo-text.completed {
   color: rgba(255, 255, 255, 0.5);
+}
+
+.dark-mode .note-todo-list::after {
+  background: linear-gradient(to bottom, transparent, #202124);
 }
 
 .note-link-previews {
@@ -701,6 +724,10 @@
 
 .oled-mode .note-todo-text.completed {
   color: rgba(255, 255, 255, 0.5);
+}
+
+.oled-mode .note-todo-list::after {
+  background: linear-gradient(to bottom, transparent, #0a0a0a);
 }
 
 .oled-mode .note-link {

--- a/client/src/components/NoteModal.css
+++ b/client/src/components/NoteModal.css
@@ -136,8 +136,6 @@
   font-family: 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   padding: 0.5rem 0;
   min-height: 150px;
-  max-height: 60vh;
-  overflow-y: auto;
 }
 
 .note-modal-content::placeholder {
@@ -398,8 +396,6 @@
   gap: 0.5rem;
   padding: 0.5rem 0;
   min-height: 150px;
-  max-height: 60vh;
-  overflow-y: auto;
 }
 
 .todo-item {


### PR DESCRIPTION
MODAL SCROLLING FIX:
- Remove max-height and overflow from textarea (.note-modal-content)
- Remove max-height and overflow from todo list container
- Now the entire modal scrolls instead of content within modal
- Better UX for long notes - scroll the popup, not the text inside

DASHBOARD NOTE LENGTH LIMITING:
- Limit note content to 6 lines (~100 characters) using -webkit-line-clamp
- Add max-height of 9em to prevent excessive vertical growth
- Apply same limit to todo lists with fade-out gradient
- Gradient adapts to theme (light/dark/OLED mode)
- Users must open modal to see full content

VISUAL IMPROVEMENTS:
- Smooth fade-out gradient at bottom of truncated todo lists
- Prevents dashboard from being cluttered with long notes
- Encourages users to click notes to see full content

FILES CHANGED:
- client/src/components/NoteModal.css: Remove scroll constraints
- client/src/components/Note.css: Add content length limits with ellipsis