### PR TITLE
Fix 405 error on DELETE - exclude /api paths from static asset caching

### DIFF
--- a/nginx-allinone.conf
+++ b/nginx-allinone.conf
@@ -56,12 +56,13 @@ server {
         expires 1y;
         add_header Cache-Control "public, immutable";
         access_log off;
+    }
 
-        # Security: Only allow image file types for GET requests
-        location ~* \.(jpg|jpeg|png|gif|webp|bmp)$ {
-            expires 1y;
-            add_header Cache-Control "public, immutable";
-        }
+    # Cache static assets aggressively (but exclude /api paths to allow DELETE/PUT/POST)
+    location ~* ^/(?!api/).*\.(jpg|jpeg|png|gif|ico|css|js|svg|woff|woff2|ttf|eot|webp|map)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        access_log off;
     }
 
     # React Router (SPA) support - must be after /api location
@@ -72,13 +73,6 @@ server {
         add_header Cache-Control "no-cache, no-store, must-revalidate";
         add_header Pragma "no-cache";
         add_header Expires "0";
-    }
-
-    # Cache static assets aggressively
-    location ~* \.(jpg|jpeg|png|gif|ico|css|js|svg|woff|woff2|ttf|eot|webp|map)$ {
-        expires 1y;
-        add_header Cache-Control "public, immutable";
-        access_log off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
The regex location for caching static assets was matching ALL files with image extensions, including /api/notes/:id/images/:filename paths. This caused nginx to treat API DELETE requests as static file requests, resulting in 405 Method Not Allowed errors.

Added negative lookahead ^/(?!api/) to exclude /api paths from the static asset caching location, allowing DELETE/PUT/POST to be proxied to the backend correctly.

Fixes: DELETE returning 405 (Not Allowed)