### PR TITLE
Fix image 404 errors - exclude /uploads from static asset regex

### DIFF
--- a/nginx-allinone.conf
+++ b/nginx-allinone.conf
@@ -58,8 +58,8 @@ server {
         access_log off;
     }
 
-    # Cache static assets aggressively (but exclude /api paths to allow DELETE/PUT/POST)
-    location ~* ^/(?!api/).*\.(jpg|jpeg|png|gif|ico|css|js|svg|woff|woff2|ttf|eot|webp|map)$ {
+    # Cache static assets aggressively (but exclude /api and /uploads paths)
+    location ~* ^/(?!api/|uploads/).*\.(jpg|jpeg|png|gif|ico|css|js|svg|woff|woff2|ttf|eot|webp|map)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
         access_log off;


### PR DESCRIPTION
nginx was looking for uploaded images in /app/client/build/uploads instead of /app/server/uploads because the regex location for static assets was matching /uploads/* paths with higher priority than the /uploads prefix location.

Added /uploads/ to the negative lookahead regex to prevent the static asset location from intercepting uploaded image requests.

Now /uploads/* requests correctly use the alias directive and serve files from /app/server/uploads.

Fixes: Images returning 404 after upload