### PR TITLE
Fix All-in-One Docker image - Add Whisper AI service integration

### DIFF
--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -34,7 +34,7 @@ FROM ubuntu:22.04
 # Prevent interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install MongoDB, Node.js, Nginx, Supervisor, and Sharp dependencies
+# Install MongoDB, Node.js, Nginx, Supervisor, Python (for AI), and dependencies
 RUN apt-get update && apt-get install -y \
     wget \
     gnupg \
@@ -43,6 +43,8 @@ RUN apt-get update && apt-get install -y \
     supervisor \
     build-essential \
     python3 \
+    python3-pip \
+    ffmpeg \
     && wget -qO - https://www.mongodb.org/static/pgp/server-7.0.asc | apt-key add - \
     && echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-7.0.list \
     && apt-get update \
@@ -71,11 +73,22 @@ COPY --from=server-builder /app/server /app/server
 WORKDIR /app/server
 RUN npm install --production && npm cache clean --force
 
+# Copy AI service files
+WORKDIR /app/ai
+COPY ai/ ./
+
+# Install Python dependencies for AI service
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+# Pre-download Whisper model to bake it into the image
+RUN python3 -c "from faster_whisper import WhisperModel; WhisperModel('tiny', device='cpu', compute_type='int8')"
+
 # Copy built client from builder
 COPY --from=client-builder /app/client/build /app/client/build
 
-# Set ownership of application files to node user
-RUN chown -R node:node /app/server
+# Set ownership of application files
+RUN chown -R node:node /app/server \
+    && chown -R root:root /app/ai
 
 # Return to /app directory
 WORKDIR /app
@@ -108,7 +121,9 @@ ENV NODE_ENV=production \
     PORT=5000 \
     MONGODB_URI=mongodb://localhost:27017/keeplocal \
     JWT_SECRET=changeme-generate-secure-secret \
-    ALLOWED_ORIGINS=*
+    ALLOWED_ORIGINS=* \
+    AI_SERVICE_URL=http://localhost:5001 \
+    WHISPER_MODEL=tiny
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,5 +1,5 @@
 # Supervisor configuration for KeepLocal All-in-One Container
-# Manages MongoDB, Node.js Backend, and Nginx
+# Manages MongoDB, Node.js Backend, AI Service (Whisper), and Nginx
 
 [supervisord]
 nodaemon=true
@@ -20,6 +20,20 @@ stderr_logfile=/var/log/supervisor/mongodb-stderr.log
 priority=1
 user=mongodb
 
+# AI Service (Whisper Transcription)
+[program:ai]
+command=/usr/local/bin/gunicorn --bind 0.0.0.0:5001 --workers 1 --timeout 300 app:app
+directory=/app/ai
+autostart=true
+autorestart=true
+startretries=10
+startsecs=10
+stdout_logfile=/var/log/supervisor/ai-stdout.log
+stderr_logfile=/var/log/supervisor/ai-stderr.log
+priority=2
+user=root
+environment=WHISPER_MODEL="%(ENV_WHISPER_MODEL)s"
+
 # Node.js Backend Service
 [program:nodejs]
 command=/usr/bin/node server.js
@@ -30,9 +44,9 @@ startretries=10
 startsecs=10
 stdout_logfile=/var/log/supervisor/nodejs-stdout.log
 stderr_logfile=/var/log/supervisor/nodejs-stderr.log
-priority=2
+priority=3
 user=node
-environment=NODE_ENV="%(ENV_NODE_ENV)s",PORT="%(ENV_PORT)s",MONGODB_URI="%(ENV_MONGODB_URI)s",JWT_SECRET="%(ENV_JWT_SECRET)s",ALLOWED_ORIGINS="%(ENV_ALLOWED_ORIGINS)s"
+environment=NODE_ENV="%(ENV_NODE_ENV)s",PORT="%(ENV_PORT)s",MONGODB_URI="%(ENV_MONGODB_URI)s",JWT_SECRET="%(ENV_JWT_SECRET)s",ALLOWED_ORIGINS="%(ENV_ALLOWED_ORIGINS)s",AI_SERVICE_URL="%(ENV_AI_SERVICE_URL)s"
 # Wait for MongoDB to be ready before starting
 depends_on=mongodb
 
@@ -45,11 +59,11 @@ startretries=10
 startsecs=5
 stdout_logfile=/var/log/supervisor/nginx-stdout.log
 stderr_logfile=/var/log/supervisor/nginx-stderr.log
-priority=3
+priority=4
 # Wait for Node.js to be ready before starting
 depends_on=nodejs
 
 # Group all services together
 [group:keeplocal]
-programs=mongodb,nodejs,nginx
+programs=mongodb,ai,nodejs,nginx
 priority=999


### PR DESCRIPTION
The GitHub Actions build was failing because Dockerfile.allinone did not include the AI service (Whisper) that was added in recent commits.

Changes to Dockerfile.allinone:
- Install Python 3, pip, and ffmpeg (required for Whisper)
- Copy AI service files to /app/ai
- Install Python dependencies (faster-whisper, Flask, gunicorn)
- Pre-download Whisper 'tiny' model to bake into image
- Add AI_SERVICE_URL and WHISPER_MODEL environment variables
- Set proper permissions for AI service files

Changes to supervisord.conf:
- Add [program:ai] service configuration
- Run AI service on port 5001 (avoiding conflict with Node.js on 5000)
- Use gunicorn with 1 worker and 300s timeout
- Set priority=2 to start after MongoDB, before Node.js
- Add AI service to keeplocal group
- Pass WHISPER_MODEL environment variable to AI service
- Update Node.js environment to include AI_SERVICE_URL

Architecture:
- MongoDB: Port 27017 (internal)
- AI Service: Port 5001 (internal)
- Node.js Backend: Port 5000 (internal)
- Nginx: Port 80 (external) - proxies to backend

This fixes the GitHub Actions build error and enables voice transcription in the all-in-one container deployment.