### PR TITLE
Fix modal auto-resize - textarea grows with content automatically

### DIFF
--- a/client/src/components/NoteModal.js
+++ b/client/src/components/NoteModal.js
@@ -64,6 +64,20 @@ function NoteModal({ note, onSave, onClose, onToggleArchive, onOpenCollaborate, 
     }
   }, [content, isTodoList]);
 
+  // Initial resize when note is loaded (handles case where content is set before textarea is rendered)
+  useEffect(() => {
+    if (note && contentTextareaRef.current && !isTodoList) {
+      // Small delay to ensure textarea is fully rendered
+      setTimeout(() => {
+        if (contentTextareaRef.current) {
+          const textarea = contentTextareaRef.current;
+          textarea.style.height = 'auto';
+          textarea.style.height = `${textarea.scrollHeight}px`;
+        }
+      }, 0);
+    }
+  }, [note, isTodoList]);
+
   const handleSave = () => {
     // Validate based on mode
     if (isTodoList) {
@@ -354,7 +368,6 @@ function NoteModal({ note, onSave, onClose, onToggleArchive, onOpenCollaborate, 
               placeholder={t('enterNote')}
               value={content}
               onChange={(e) => setContent(e.target.value)}
-              rows={12}
             />
           )}
 


### PR DESCRIPTION
Fixed the modal scrolling issue where the note modal did not automatically scale to the note content length. Users previously had to manually scroll within the modal.

Changes to NoteModal.js:
- Removed `rows={12}` attribute from textarea (was forcing fixed height)
- Added additional useEffect for initial resize when note loads
- Used setTimeout(0) to ensure textarea is fully rendered before resize
- Auto-resize now works on:
  1. Content change (typing)
  2. Note load (opening modal)
  3. Todo list toggle

How it works:
- Textarea has min-height: 100px (from CSS)
- JavaScript sets height to 'auto' then to scrollHeight
- Modal grows with textarea content
- Page scrolls when modal exceeds viewport height (via overlay overflow-y: auto)

User experience:
- No more manual scrolling inside modal
- Modal automatically fits content
- Long notes scroll the page, not the modal
- Smooth auto-resize as user types