### PR TITLE
Fix Docker build - Add PyAV build dependencies

### DIFF
--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -44,7 +44,15 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     python3 \
     python3-pip \
+    python3-dev \
+    pkg-config \
     ffmpeg \
+    libavcodec-dev \
+    libavformat-dev \
+    libavutil-dev \
+    libswscale-dev \
+    libswresample-dev \
+    libavdevice-dev \
     && wget -qO - https://www.mongodb.org/static/pgp/server-7.0.asc | apt-key add - \
     && echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-7.0.list \
     && apt-get update \


### PR DESCRIPTION
Adds pkg-config and FFmpeg development libraries required for compiling PyAV (dependency of faster-whisper). This resolves the build failure: "pkg-config is required for building PyAV"