### PR TITLE
Fix note gradient transition and UI improvements

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -72,7 +72,7 @@
   --accent-hover: #aecbfa;
 
   /* Note Colors - OLED Mode (very dark variants) */
-  --note-white: #0a0a0a;
+  --note-white: #1a1a1a;
   --note-red: #3d1a18;
   --note-orange: #3d2f0f;
   --note-yellow: #3d3a0f;
@@ -83,7 +83,7 @@
   --note-purple: #241535;
   --note-pink: #35142a;
   --note-brown: #291e0f;
-  --note-gray: #1a1a1a;
+  --note-gray: #252525;
 }
 
 * {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -441,20 +441,14 @@ function AppContent() {
           <div className="user-info">
             <LanguageSelector />
             <ThemeToggle theme={theme} onToggle={toggleTheme} />
-            {user?.isAdmin ? (
-              <button
-                className="user-name clickable"
-                onClick={() => setShowAdminConsole(true)}
-                title={`${user?.email} (${t('admin')} - ${t('openAdminPanel')})`}
-                aria-label={t('openAdminPanel')}
-              >
-                👤 {user?.username}
-              </button>
-            ) : (
-              <span className="user-name" title={user?.email}>
-                👤 {user?.username}
-              </span>
-            )}
+            <button
+              className="user-name clickable"
+              onClick={() => setShowSettings(true)}
+              title={`${user?.email}${user?.isAdmin ? ` (${t('admin')})` : ''}`}
+              aria-label={t('settings') || 'Einstellungen'}
+            >
+              👤 {user?.username}
+            </button>
             <button
               onClick={handleLogout}
               className="btn-logout"
@@ -485,7 +479,6 @@ function AppContent() {
           showArchived={showArchived}
           onShowArchivedToggle={() => setShowArchived(!showArchived)}
           onOpenFriends={() => setShowFriendsModal(true)}
-          onOpenSettings={() => setShowSettings(true)}
         />
 
         <main className="App-main" role="main">

--- a/client/src/components/Note.css
+++ b/client/src/components/Note.css
@@ -79,6 +79,18 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
   max-height: 9em;
+  position: relative;
+}
+
+.note-content::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 2em;
+  background: linear-gradient(to bottom, transparent, var(--note-bg-color, var(--bg-primary)));
+  pointer-events: none;
 }
 
 .note-todo-list {
@@ -99,7 +111,7 @@
   left: 0;
   right: 0;
   height: 2em;
-  background: linear-gradient(to bottom, transparent, var(--bg-primary));
+  background: linear-gradient(to bottom, transparent, var(--note-bg-color, var(--bg-primary)));
   pointer-events: none;
 }
 
@@ -140,9 +152,6 @@
   color: rgba(255, 255, 255, 0.5);
 }
 
-.dark-mode .note-todo-list::after {
-  background: linear-gradient(to bottom, transparent, #202124);
-}
 
 .note-link-previews {
   margin-top: 0.75rem;
@@ -726,9 +735,6 @@
   color: rgba(255, 255, 255, 0.5);
 }
 
-.oled-mode .note-todo-list::after {
-  background: linear-gradient(to bottom, transparent, #0a0a0a);
-}
 
 .oled-mode .note-link {
   color: #8ab4f8;

--- a/client/src/components/Note.js
+++ b/client/src/components/Note.js
@@ -107,7 +107,10 @@ function Note({ note, onDelete, onUpdate, onTogglePin, onToggleArchive, onOpenCo
   return (
     <div
       className={`note ${isDragging ? 'dragging' : ''} ${dragOverTag ? 'drag-over-tag' : ''}`}
-      style={{ backgroundColor: getColorVar(note.color) }}
+      style={{
+        backgroundColor: getColorVar(note.color),
+        '--note-bg-color': getColorVar(note.color)
+      }}
       onClick={() => onOpenModal(note)}
       draggable="true"
       onDragStart={handleDragStart}

--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -14,7 +14,6 @@ function Sidebar({
   showArchived,
   onShowArchivedToggle,
   onOpenFriends,
-  onOpenSettings,
   isAdmin,
   onAdminClick,
   user,
@@ -127,21 +126,6 @@ function Sidebar({
             <path d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75"/>
           </svg>
           <span>{t('friends')}</span>
-        </button>
-
-        <button
-          className="sidebar-item"
-          onClick={() => {
-            onOpenSettings();
-            onMobileClose();
-          }}
-          aria-label={t('settings') || 'Einstellungen'}
-        >
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-            <circle cx="12" cy="12" r="3"/>
-            <path d="M12 1v6m0 6v6M5.64 5.64l4.24 4.24m4.24 4.24l4.24 4.24M1 12h6m6 0h6M5.64 18.36l4.24-4.24m4.24-4.24l4.24-4.24"/>
-          </svg>
-          <span>{t('settings') || 'Einstellungen'}</span>
         </button>
 
         {isAdmin && (


### PR DESCRIPTION
- Fixed gradient transition to adapt to note color instead of using fixed background colors
- Made default note color lighter in OLED mode (#1a1a1a instead of #0a0a0a)
- Unified Settings option on username click for all users
- Removed duplicate Settings button from sidebar
- Added CSS custom property --note-bg-color for dynamic gradient colors