### PR TITLE
Add e-ink display mode option

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -86,6 +86,43 @@
   --note-gray: #252525;
 }
 
+/* E-Ink Mode - High contrast black & white, no gradients, no animations */
+.eink-mode {
+  --bg-primary: #ffffff;
+  --bg-secondary: #f5f5f5;
+  --text-primary: #000000;
+  --text-secondary: #333333;
+  --text-muted: #666666;
+  --border-color: #000000;
+  --shadow-sm: none;
+  --shadow-md: none;
+  --accent-color: #000000;
+  --accent-hover: #333333;
+
+  /* Note Colors - E-Ink Mode (grayscale only) */
+  --note-white: #ffffff;
+  --note-red: #e0e0e0;
+  --note-orange: #d5d5d5;
+  --note-yellow: #ebebeb;
+  --note-green: #e8e8e8;
+  --note-teal: #e5e5e5;
+  --note-cyan: #e2e2e2;
+  --note-blue: #e0e0e0;
+  --note-purple: #d8d8d8;
+  --note-pink: #e5e5e5;
+  --note-brown: #d0d0d0;
+  --note-gray: #cccccc;
+}
+
+/* Disable all animations and transitions in E-Ink mode */
+.eink-mode,
+.eink-mode *,
+.eink-mode *::before,
+.eink-mode *::after {
+  animation: none !important;
+  transition: none !important;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -122,6 +159,11 @@ body.oled-mode {
   background-attachment: fixed;
 }
 
+body.eink-mode {
+  background: #ffffff;
+  background-attachment: fixed;
+}
+
 .App {
   height: 100vh !important;
   background: transparent;
@@ -151,6 +193,13 @@ body.oled-mode {
   color: #ffffff;
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.eink-mode .App-header {
+  background: #ffffff;
+  color: #000000;
+  border-bottom: 2px solid #000000;
+  box-shadow: none;
 }
 
 .header-content {
@@ -258,6 +307,17 @@ body.oled-mode {
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
 }
 
+.eink-mode .user-name {
+  background: #f0f0f0;
+  color: #000000;
+  border: 1px solid #000000;
+}
+
+.eink-mode .user-name.clickable:hover {
+  background: #e0e0e0;
+  box-shadow: none;
+}
+
 .btn-logout {
   padding: 8px 24px;
   background: transparent;
@@ -331,6 +391,24 @@ body.oled-mode {
   background: rgba(255, 255, 255, 0.2);
   border-color: rgba(255, 255, 255, 0.6);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+
+.eink-mode .btn-logout {
+  border: 2px solid #000000;
+  color: #000000;
+  background: #ffffff;
+}
+
+.eink-mode .btn-logout::before {
+  display: none;
+}
+
+.eink-mode .btn-logout:hover {
+  background: #000000;
+  color: #ffffff;
+  border-color: #000000;
+  box-shadow: none;
+  transform: none;
 }
 
 .App-container {
@@ -632,6 +710,15 @@ body.oled-mode {
 
 .oled-mode .mobile-menu-toggle:hover {
   background: rgba(255, 255, 255, 0.2);
+}
+
+.eink-mode .mobile-menu-toggle {
+  color: #000000;
+  border: 1px solid #000000;
+}
+
+.eink-mode .mobile-menu-toggle:hover {
+  background: #e0e0e0;
 }
 
 @media (max-width: 768px) {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -37,7 +37,7 @@ function AppContent() {
   const [operationLoading, setOperationLoading] = useState({});
   const [theme, setTheme] = useState(() => {
     const savedTheme = localStorage.getItem('theme');
-    return savedTheme || 'light'; // 'light', 'dark', or 'oled'
+    return savedTheme || 'light'; // 'light', 'dark', 'oled', or 'eink'
   });
   const [draggedNoteId, setDraggedNoteId] = useState(null);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
@@ -63,13 +63,15 @@ function AppContent() {
   // Theme anwenden
   useEffect(() => {
     // Remove all theme classes
-    document.body.classList.remove('dark-mode', 'oled-mode');
+    document.body.classList.remove('dark-mode', 'oled-mode', 'eink-mode');
 
     // Add appropriate theme class
     if (theme === 'dark') {
       document.body.classList.add('dark-mode');
     } else if (theme === 'oled') {
       document.body.classList.add('oled-mode');
+    } else if (theme === 'eink') {
+      document.body.classList.add('eink-mode');
     }
 
     localStorage.setItem('theme', theme);
@@ -279,10 +281,11 @@ function AppContent() {
 
   // Theme umschalten
   const toggleTheme = () => {
-    // Cycle through themes: light -> dark -> oled -> light
+    // Cycle through themes: light -> dark -> oled -> eink -> light
     setTheme(prevTheme => {
       if (prevTheme === 'light') return 'dark';
       if (prevTheme === 'dark') return 'oled';
+      if (prevTheme === 'oled') return 'eink';
       return 'light';
     });
   };

--- a/client/src/components/Note.css
+++ b/client/src/components/Note.css
@@ -763,6 +763,129 @@
   background: rgba(91, 185, 116, 0.15);
 }
 
+/* E-Ink mode */
+.eink-mode .note {
+  box-shadow: none;
+  border: 2px solid #000000;
+  background: #ffffff;
+}
+
+.eink-mode .note:hover {
+  box-shadow: none;
+  background: #f5f5f5;
+}
+
+.eink-mode .note-title,
+.eink-mode .note-content,
+.eink-mode .note-edit-title,
+.eink-mode .note-edit-content {
+  color: #000000;
+}
+
+.eink-mode .note-tag {
+  background: #e0e0e0;
+  color: #000000;
+  border: 1px solid #000000;
+}
+
+.eink-mode .note-edit-tags {
+  color: #333333;
+  border-top-color: #000000;
+}
+
+.eink-mode .action-btn,
+.eink-mode .toolbar-btn {
+  color: #000000;
+}
+
+.eink-mode .action-btn:hover,
+.eink-mode .toolbar-btn:hover {
+  background: #e0e0e0;
+}
+
+.eink-mode .action-btn:active,
+.eink-mode .toolbar-btn:active {
+  background: #cccccc;
+}
+
+.eink-mode .btn-text {
+  color: #000000;
+}
+
+.eink-mode .btn-text:hover {
+  background: #e0e0e0;
+}
+
+.eink-mode .btn-text:active {
+  background: #cccccc;
+}
+
+.eink-mode .pin-btn.pinned {
+  color: #000000;
+  background: #cccccc;
+}
+
+.eink-mode .pin-btn.pinned svg {
+  fill: #000000;
+}
+
+.eink-mode .note-todo-text {
+  color: #000000;
+}
+
+.eink-mode .note-todo-text.completed {
+  color: #666666;
+}
+
+.eink-mode .note-link {
+  color: #000000;
+  text-decoration: underline;
+}
+
+.eink-mode .todo-checkbox {
+  background: #ffffff;
+  border-color: #000000;
+  border-width: 2px;
+}
+
+.eink-mode .todo-checkbox:hover {
+  background: #e0e0e0;
+}
+
+.eink-mode .todo-checkbox:checked {
+  background: #000000;
+  border-color: #000000;
+}
+
+.eink-mode .note.drag-over-tag {
+  border: 2px dashed #000000;
+  background: #e0e0e0;
+}
+
+.eink-mode .note-collaborators {
+  color: #333333;
+}
+
+.eink-mode .collaborator-avatar {
+  background: #000000;
+  color: #ffffff;
+  border: 2px solid #ffffff;
+}
+
+.eink-mode .collaborator-avatar.more {
+  background: #666666;
+}
+
+.eink-mode .note-image-preview {
+  background: #f0f0f0;
+  border: 1px solid #000000;
+}
+
+.eink-mode .note-content::after,
+.eink-mode .note-todo-list::after {
+  background: linear-gradient(to bottom, transparent, #ffffff);
+}
+
 /* Responsive */
 @media (max-width: 768px) {
   .note {

--- a/client/src/components/NoteForm.css
+++ b/client/src/components/NoteForm.css
@@ -163,6 +163,36 @@
   box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.5), 0 4px 12px 4px rgba(0, 0, 0, 0.3);
 }
 
+/* E-Ink mode adjustments */
+.eink-mode .note-form-button {
+  box-shadow: none;
+  border: 2px solid #000000;
+  background: #ffffff;
+}
+
+.eink-mode .note-form-button:hover {
+  box-shadow: none;
+  background: #f5f5f5;
+}
+
+.eink-mode .note-form-tags {
+  border-top-color: #000000;
+}
+
+.eink-mode .btn-primary {
+  background: #000000;
+  color: #ffffff;
+}
+
+.eink-mode .btn-primary:hover:not(:disabled) {
+  background: #333333;
+  box-shadow: none;
+}
+
+.eink-mode .btn-secondary:hover:not(:disabled) {
+  background: #e0e0e0;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
   .note-form-container {

--- a/client/src/components/NoteModal.css
+++ b/client/src/components/NoteModal.css
@@ -1020,6 +1020,233 @@
   color: #8ab4f8;
 }
 
+/* E-Ink mode */
+.eink-mode .note-modal {
+  background: #ffffff;
+  box-shadow: none;
+  border: 2px solid #000000;
+}
+
+.eink-mode .note-modal-close {
+  color: #000000;
+  border: 1px solid #000000;
+}
+
+.eink-mode .note-modal-close:hover {
+  background: #e0e0e0;
+  color: #000000;
+}
+
+.eink-mode .note-modal-title {
+  color: #000000;
+  border-bottom-color: #000000;
+}
+
+.eink-mode .note-modal-title::placeholder {
+  color: #666666;
+}
+
+.eink-mode .note-modal-content {
+  color: #000000;
+}
+
+.eink-mode .note-modal-content::placeholder {
+  color: #666666;
+}
+
+.eink-mode .note-modal-tags {
+  color: #333333;
+}
+
+.eink-mode .note-modal-tags::placeholder {
+  color: #666666;
+}
+
+.eink-mode .note-modal-tags-input {
+  color: #333333;
+}
+
+.eink-mode .note-modal-tags-input::placeholder {
+  color: #666666;
+}
+
+.eink-mode .tag-pill {
+  background: #e0e0e0;
+  border: 1px solid #000000;
+  color: #000000;
+}
+
+.eink-mode .tag-pill:hover {
+  background: #cccccc;
+  border-color: #000000;
+  box-shadow: none;
+  transform: none;
+}
+
+.eink-mode .btn-modal-cancel {
+  background: #ffffff;
+  color: #000000;
+  border: 2px solid #000000;
+}
+
+.eink-mode .btn-modal-cancel:hover {
+  background: #e0e0e0;
+  border-color: #000000;
+}
+
+.eink-mode .btn-modal-save {
+  background: #000000;
+  color: #ffffff;
+  box-shadow: none;
+}
+
+.eink-mode .btn-modal-save:hover:not(:disabled) {
+  background: #333333;
+  transform: none;
+  box-shadow: none;
+}
+
+.eink-mode .btn-modal-checkbox {
+  color: #000000;
+}
+
+.eink-mode .btn-modal-checkbox:hover {
+  background: #e0e0e0;
+}
+
+.eink-mode .btn-modal-checkbox:active {
+  background: #cccccc;
+}
+
+.eink-mode .btn-modal-checkbox.active {
+  background: #cccccc;
+  color: #000000;
+}
+
+.eink-mode .btn-modal-archive,
+.eink-mode .btn-modal-collaborate,
+.eink-mode .btn-modal-pin,
+.eink-mode .btn-modal-delete {
+  color: #000000;
+}
+
+.eink-mode .btn-modal-archive:hover,
+.eink-mode .btn-modal-collaborate:hover,
+.eink-mode .btn-modal-pin:hover {
+  background: #e0e0e0;
+}
+
+.eink-mode .btn-modal-archive:active,
+.eink-mode .btn-modal-collaborate:active,
+.eink-mode .btn-modal-pin:active {
+  background: #cccccc;
+}
+
+.eink-mode .btn-modal-archive.archived {
+  background: #cccccc;
+  color: #000000;
+}
+
+.eink-mode .btn-modal-pin.pinned {
+  background: #cccccc;
+  color: #000000;
+}
+
+.eink-mode .btn-modal-delete:hover {
+  background: #e0e0e0;
+  color: #000000;
+}
+
+.eink-mode .todo-item:hover {
+  border-bottom-color: #000000;
+  background: #f5f5f5;
+}
+
+.eink-mode .todo-item-input {
+  color: #000000;
+}
+
+.eink-mode .todo-item-input.completed {
+  color: #666666;
+}
+
+.eink-mode .todo-item-input::placeholder {
+  color: #666666;
+}
+
+.eink-mode .todo-item-delete {
+  color: #666666;
+}
+
+.eink-mode .todo-item-delete:hover {
+  background: #e0e0e0;
+  color: #000000;
+}
+
+.eink-mode .todo-add-item {
+  color: #666666;
+}
+
+.eink-mode .todo-add-item:hover {
+  background: #e0e0e0;
+  color: #000000;
+}
+
+.eink-mode .btn-modal-image-select,
+.eink-mode .btn-modal-image-upload {
+  color: #000000;
+}
+
+.eink-mode .btn-modal-image-select:hover,
+.eink-mode .btn-modal-image-upload:hover {
+  background: #e0e0e0;
+}
+
+.eink-mode .btn-modal-image-select:active,
+.eink-mode .btn-modal-image-upload:active {
+  background: #cccccc;
+}
+
+.eink-mode .btn-modal-image-upload.uploading {
+  background: #cccccc;
+  color: #000000;
+}
+
+.eink-mode .image-preview {
+  border-color: #000000;
+}
+
+.eink-mode .image-preview:hover {
+  border-color: #000000;
+  border-width: 2px;
+}
+
+.eink-mode .btn-modal-voice {
+  color: #000000;
+}
+
+.eink-mode .btn-modal-voice:hover {
+  background: #e0e0e0;
+}
+
+.eink-mode .btn-modal-voice:active {
+  background: #cccccc;
+}
+
+.eink-mode .btn-modal-voice.recording {
+  background: #cccccc;
+  color: #000000;
+}
+
+.eink-mode .btn-modal-voice.recording:hover {
+  background: #b0b0b0;
+}
+
+.eink-mode .btn-modal-voice.transcribing {
+  background: #e0e0e0;
+  color: #000000;
+}
+
 /* Lightbox styles */
 .lightbox-overlay {
   position: fixed;

--- a/client/src/components/SearchBar.css
+++ b/client/src/components/SearchBar.css
@@ -62,6 +62,22 @@
   color: #333;
 }
 
+/* E-Ink mode */
+.eink-mode .search-input {
+  border: 2px solid #000000;
+  background: #ffffff;
+}
+
+.eink-mode .search-input:focus {
+  border-color: #000000;
+  box-shadow: none;
+}
+
+.eink-mode .search-clear:hover {
+  background: #e0e0e0;
+  color: #000000;
+}
+
 @media (max-width: 768px) {
   .search-bar {
     max-width: 100%;

--- a/client/src/components/Sidebar.css
+++ b/client/src/components/Sidebar.css
@@ -19,6 +19,11 @@
   border-right: 1px solid rgba(255, 255, 255, 0.1);
 }
 
+.eink-mode .sidebar {
+  background: #ffffff;
+  border-right: 2px solid #000000;
+}
+
 .sidebar.collapsed {
   width: 72px;
 }
@@ -51,6 +56,10 @@
 
 .oled-mode .sidebar-toggle:hover {
   background: rgba(255, 255, 255, 0.1);
+}
+
+.eink-mode .sidebar-toggle:hover {
+  background: #e0e0e0;
 }
 
 .sidebar-nav {
@@ -108,6 +117,16 @@
   color: #87CEEB;
 }
 
+.eink-mode .sidebar-item:hover {
+  background: #e0e0e0;
+}
+
+.eink-mode .sidebar-item.active {
+  background: #cccccc;
+  color: #000000;
+  border: 1px solid #000000;
+}
+
 .sidebar-admin {
   color: #667eea;
   font-weight: 600;
@@ -123,6 +142,11 @@
 
 .oled-mode .sidebar-admin {
   color: #8ab4f8;
+}
+
+.eink-mode .sidebar-admin {
+  color: #000000;
+  font-weight: 700;
 }
 
 .sidebar-item svg {
@@ -211,6 +235,12 @@
     box-shadow: 2px 0 16px rgba(0, 0, 0, 0.6);
   }
 
+  .eink-mode .sidebar {
+    background: #ffffff;
+    box-shadow: none;
+    border-right: 2px solid #000000;
+  }
+
   .sidebar.mobile-open {
     transform: translateX(0);
   }
@@ -236,6 +266,10 @@
 
   .oled-mode .sidebar-mobile-logo {
     border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+  }
+
+  .eink-mode .sidebar-mobile-logo {
+    border-bottom: 2px solid #000000;
   }
 
   .sidebar-mobile-logo .logo-container {
@@ -296,6 +330,18 @@
     box-shadow: 0 2px 8px rgba(135, 206, 235, 0.25);
   }
 
+  .eink-mode .sidebar-mobile-user {
+    background: #f0f0f0;
+    border: 2px solid #000000;
+  }
+
+  .eink-mode .sidebar-mobile-user:hover {
+    background: #e0e0e0;
+    border: 2px solid #000000;
+    box-shadow: none;
+    transform: none;
+  }
+
   .mobile-user-icon {
     font-size: 32px;
   }
@@ -353,6 +399,19 @@
 
   .oled-mode .sidebar-mobile-logout:hover {
     background: rgba(135, 206, 235, 1);
+  }
+
+  .eink-mode .sidebar-mobile-logout {
+    background: #ffffff;
+    color: #000000;
+    border: 2px solid #000000;
+  }
+
+  .eink-mode .sidebar-mobile-logout:hover {
+    background: #000000;
+    color: #ffffff;
+    transform: none;
+    box-shadow: none;
   }
 
   .sidebar-mobile-logout svg {

--- a/client/src/components/ThemeToggle.js
+++ b/client/src/components/ThemeToggle.js
@@ -9,12 +9,14 @@ function ThemeToggle({ theme, onToggle }) {
   const getThemeIcon = () => {
     if (theme === 'light') return '☀️'; // Currently light mode
     if (theme === 'dark') return '🌙'; // Currently dark mode
-    return '⚫'; // Currently OLED mode
+    if (theme === 'oled') return '⚫'; // Currently OLED mode
+    return '📰'; // Currently E-Ink mode
   };
 
   const getThemeTitle = () => {
     if (theme === 'light') return t('switchToDarkMode');
     if (theme === 'dark') return t('switchToOledMode');
+    if (theme === 'oled') return t('switchToEinkMode');
     return t('switchToLightMode');
   };
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -55,6 +55,19 @@ body.dark-mode {
   --shadow-lg: 0 10px 40px rgba(0, 0, 0, 0.7);
 }
 
+body.eink-mode {
+  --bg-primary: #ffffff;
+  --bg-secondary: #f5f5f5;
+  --text-primary: #000000;
+  --text-secondary: #333333;
+  --text-tertiary: #555555;
+  --text-muted: #666666;
+  --border-color: #000000;
+  --shadow-sm: none;
+  --shadow-md: none;
+  --shadow-lg: none;
+}
+
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;

--- a/client/src/translations/de.js
+++ b/client/src/translations/de.js
@@ -145,6 +145,7 @@ export const de = {
   switchToLightMode: 'Zum hellen Modus wechseln',
   switchToDarkMode: 'Zum dunklen Modus wechseln',
   switchToOledMode: 'Zum OLED-Modus wechseln',
+  switchToEinkMode: 'Zum E-Ink-Modus wechseln',
   switchToNote: 'Zu Notiz wechseln',
   switchToList: 'Zu Liste wechseln',
 

--- a/client/src/translations/en.js
+++ b/client/src/translations/en.js
@@ -145,6 +145,7 @@ export const en = {
   switchToLightMode: 'Switch to light mode',
   switchToDarkMode: 'Switch to dark mode',
   switchToOledMode: 'Switch to OLED mode',
+  switchToEinkMode: 'Switch to E-Ink mode',
   switchToNote: 'Switch to note',
   switchToList: 'Switch to list',
 


### PR DESCRIPTION
- Add 'eink' to theme cycle: light -> dark -> oled -> eink -> light
- Implement high-contrast black & white E-Ink CSS variables
- Disable all animations/transitions for E-Ink displays
- Add E-Ink styles to all major components (Sidebar, Note, NoteModal, etc.)
- Add German/English translations for E-Ink mode switch
- Use grayscale note colors for E-Ink compatibility