### PR TITLE
Fix service worker cache and image upload errors

### DIFF
--- a/server/middleware/upload.js
+++ b/server/middleware/upload.js
@@ -74,7 +74,7 @@ const audioFileFilter = (req, file, cb) => {
 const upload = multer({
   storage: storage,
   limits: {
-    fileSize: 5 * 1024 * 1024, // 5MB max file size
+    fileSize: 10 * 1024 * 1024, // 10MB max file size
   },
   fileFilter: fileFilter
 });


### PR DESCRIPTION
- Filter out chrome-extension:// requests in service worker
- Only cache http/https responses with basic type
- Add error handling for cache.put failures
- Increase image upload limit from 5MB to 10MB
- Add proper error handling for multer file size errors
- Return user-friendly error messages for upload failures