### PR TITLE
Fix API errors and service worker issues

### DIFF
--- a/server/middleware/validators.js
+++ b/server/middleware/validators.js
@@ -26,8 +26,8 @@ const noteValidationRules = {
     body('content')
       .optional({ checkFalsy: true })
       .trim()
-      .isLength({ max: 10000 })
-      .withMessage('Inhalt darf maximal 10.000 Zeichen lang sein'),
+      .isLength({ max: 100000 })
+      .withMessage('Inhalt darf maximal 100.000 Zeichen lang sein'),
 
     body('color')
       .optional()
@@ -130,8 +130,8 @@ const noteValidationRules = {
     body('content')
       .optional({ checkFalsy: true })
       .trim()
-      .isLength({ max: 10000 })
-      .withMessage('Inhalt darf maximal 10.000 Zeichen lang sein'),
+      .isLength({ max: 100000 })
+      .withMessage('Inhalt darf maximal 100.000 Zeichen lang sein'),
 
     body('color')
       .optional()


### PR DESCRIPTION
The 10,000 character limit was too restrictive for longer notes, causing 400 validation errors when saving large texts.