### PR TITLE
Check for exposed personal data and API keys

### DIFF
--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -131,7 +131,6 @@ VOLUME ["/data/db", "/app/server/uploads"]
 ENV NODE_ENV=production \
     PORT=5000 \
     MONGODB_URI=mongodb://localhost:27017/keeplocal \
-    JWT_SECRET=changeme-generate-secure-secret \
     ALLOWED_ORIGINS=* \
     AI_SERVICE_URL=http://localhost:5001 \
     WHISPER_MODEL=tiny

--- a/docker-compose.allinone.yml
+++ b/docker-compose.allinone.yml
@@ -14,7 +14,7 @@ services:
       - NODE_ENV=production
       - PORT=5000
       - MONGODB_URI=mongodb://localhost:27017/keeplocal
-      - JWT_SECRET=${JWT_SECRET:-please-change-this-to-a-secure-random-string}
+      - JWT_SECRET=${JWT_SECRET:?JWT_SECRET environment variable is required}
       - ALLOWED_ORIGINS=*
     volumes:
       # CRITICAL: Map uploads directory to persist images across container restarts

--- a/docker-compose.npm.yml
+++ b/docker-compose.npm.yml
@@ -31,7 +31,7 @@ services:
       - MONGODB_URI=mongodb://mongodb:27017/keeplocal
       # WICHTIG: Füge hier deine Domain hinzu!
       - ALLOWED_ORIGINS=http://localhost:3000,http://localhost,https://keeplocal.deine-domain.de,https://deine-domain.de
-      - JWT_SECRET=${JWT_SECRET:-change-this-secret-in-production-please-use-long-random-string}
+      - JWT_SECRET=${JWT_SECRET:?JWT_SECRET environment variable is required}
       - JWT_EXPIRES_IN=7d
     volumes:
       - uploads_data:/app/server/uploads

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - PORT=5000
       - MONGODB_URI=mongodb://mongodb:27017/keeplocal
       - ALLOWED_ORIGINS=http://localhost:3000,http://localhost
-      - JWT_SECRET=${JWT_SECRET:-change-this-secret-in-production-please-use-long-random-string}
+      - JWT_SECRET=${JWT_SECRET:?JWT_SECRET environment variable is required}
       - JWT_EXPIRES_IN=7d
       - AI_SERVICE_URL=http://ai:5000  # AI service endpoint
     volumes:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,23 @@ set -e
 
 echo "=== KeepLocal Container Starting ==="
 
+# Validate JWT_SECRET is set and secure
+echo "Checking JWT_SECRET configuration..."
+if [ -z "$JWT_SECRET" ]; then
+    echo "ERROR: JWT_SECRET environment variable is not set!"
+    echo "Please set a secure JWT_SECRET (minimum 32 characters)."
+    echo "Example: docker run -e JWT_SECRET=\$(openssl rand -base64 32) ..."
+    exit 1
+fi
+
+if [ ${#JWT_SECRET} -lt 32 ]; then
+    echo "ERROR: JWT_SECRET must be at least 32 characters long!"
+    echo "Current length: ${#JWT_SECRET}"
+    echo "Please use a stronger secret. Example: openssl rand -base64 32"
+    exit 1
+fi
+echo "✓ JWT_SECRET is configured correctly"
+
 # Fix MongoDB data directory permissions
 echo "Checking /data/db permissions..."
 if [ -d "/data/db" ]; then


### PR DESCRIPTION
- Remove hardcoded default JWT_SECRET from Dockerfile.allinone
- Replace fallback secrets with required variable syntax in docker-compose files
- Add JWT_SECRET validation in entrypoint.sh (requires min 32 chars)
- Container will now fail to start without proper JWT_SECRET configuration

This prevents authentication bypass when deploying without setting JWT_SECRET.