### PR TITLE
Auto-detect language from browser and remove admin from sidebar

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -5,7 +5,6 @@ import NoteList from './components/NoteList';
 import SearchBar from './components/SearchBar';
 import Sidebar from './components/Sidebar';
 import ThemeToggle from './components/ThemeToggle';
-import LanguageSelector from './components/LanguageSelector';
 import Toast from './components/Toast';
 import Login from './components/Login';
 import Register from './components/Register';
@@ -378,7 +377,6 @@ function AppContent() {
       <>
         <div className="floating-controls">
           <ThemeToggle theme={theme} onToggle={toggleTheme} />
-          <LanguageSelector />
         </div>
         <Setup onSetup={handleSetup} />
         {toast && (
@@ -398,7 +396,6 @@ function AppContent() {
       <>
         <div className="floating-controls">
           <ThemeToggle theme={theme} onToggle={toggleTheme} />
-          <LanguageSelector />
         </div>
         {showRegister ? (
           <Register
@@ -443,8 +440,7 @@ function AppContent() {
             aria-label={t('searchNotes')}
           />
           <div className="user-info">
-            <LanguageSelector />
-            <ThemeToggle theme={theme} onToggle={toggleTheme} />
+              <ThemeToggle theme={theme} onToggle={toggleTheme} />
             <button
               className="user-name clickable"
               onClick={() => setShowSettings(true)}

--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import ThemeToggle from './ThemeToggle';
-import LanguageSelector from './LanguageSelector';
 import Logo from './Logo';
 import { useLanguage } from '../contexts/LanguageContext';
 import './Sidebar.css';
@@ -14,8 +13,6 @@ function Sidebar({
   showArchived,
   onShowArchivedToggle,
   onOpenFriends,
-  isAdmin,
-  onAdminClick,
   onSettingsClick,
   user,
   onLogout,
@@ -69,7 +66,6 @@ function Sidebar({
         </button>
 
         <div className="sidebar-mobile-actions">
-          <LanguageSelector />
           <ThemeToggle theme={theme} onToggle={onThemeToggle} />
         </div>
 
@@ -135,26 +131,6 @@ function Sidebar({
           </svg>
           <span>{t('friends')}</span>
         </button>
-
-        {isAdmin && (
-          <>
-            <div className="sidebar-divider"></div>
-            <button
-              className="sidebar-item sidebar-admin"
-              onClick={() => {
-                onAdminClick();
-                onMobileClose();
-              }}
-              aria-label={t('adminConsole')}
-            >
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <path d="M12 15a3 3 0 100-6 3 3 0 000 6z"/>
-                <path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-2 2 2 2 0 01-2-2v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83 0 2 2 0 010-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 01-2-2 2 2 0 012-2h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 010-2.83 2 2 0 012.83 0l.06.06a1.65 1.65 0 001.82.33H9a1.65 1.65 0 001-1.51V3a2 2 0 012-2 2 2 0 012 2v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 0 2 2 0 010 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9a1.65 1.65 0 001.51 1H21a2 2 0 012 2 2 2 0 01-2 2h-.09a1.65 1.65 0 00-1.51 1z"/>
-              </svg>
-              <span>{t('admin')}</span>
-            </button>
-          </>
-        )}
 
         {allTags.length > 0 && (
           <>

--- a/client/src/contexts/LanguageContext.js
+++ b/client/src/contexts/LanguageContext.js
@@ -3,40 +3,33 @@ import { translations, defaultLanguage } from '../translations';
 
 const LanguageContext = createContext();
 
+function getBrowserLanguage() {
+  const browserLang = navigator.language.split('-')[0];
+  if (translations[browserLang]) {
+    return browserLang;
+  }
+  return defaultLanguage;
+}
+
 export function LanguageProvider({ children }) {
-  const [language, setLanguage] = useState(() => {
-    // Load saved language from localStorage or use browser language
-    const savedLanguage = localStorage.getItem('language');
-    if (savedLanguage && translations[savedLanguage]) {
-      return savedLanguage;
-    }
+  const [language, setLanguage] = useState(getBrowserLanguage);
 
-    // Detect browser language
-    const browserLang = navigator.language.split('-')[0]; // 'de-DE' -> 'de'
-    if (translations[browserLang]) {
-      return browserLang;
-    }
-
-    return defaultLanguage;
-  });
-
-  // Save language to localStorage when it changes
+  // Listen for browser language changes
   useEffect(() => {
-    localStorage.setItem('language', language);
-  }, [language]);
+    function handleLanguageChange() {
+      setLanguage(getBrowserLanguage());
+    }
+
+    window.addEventListener('languagechange', handleLanguageChange);
+    return () => window.removeEventListener('languagechange', handleLanguageChange);
+  }, []);
 
   const t = (key) => {
     return translations[language]?.[key] || translations[defaultLanguage]?.[key] || key;
   };
 
-  const changeLanguage = (newLanguage) => {
-    if (translations[newLanguage]) {
-      setLanguage(newLanguage);
-    }
-  };
-
   return (
-    <LanguageContext.Provider value={{ language, changeLanguage, t }}>
+    <LanguageContext.Provider value={{ language, t }}>
       {children}
     </LanguageContext.Provider>
   );


### PR DESCRIPTION
Language now automatically follows the browser's language setting via navigator.language, and reacts to runtime changes via the 'languagechange' event. Removed the manual LanguageSelector component from the header, setup, login, and mobile sidebar views. Removed the localStorage persistence since the browser is the source of truth.

Removed the admin settings button from the sidebar since it's already accessible via the username click -> Settings -> Administration path.
