### PR TITLE
Add API Key Management and External REST API (v1)

### DIFF
--- a/client/src/components/Settings.css
+++ b/client/src/components/Settings.css
@@ -446,6 +446,153 @@ input:checked + .toggle-slider:before {
   box-shadow: 0 4px 16px rgba(138, 180, 248, 0.6);
 }
 
+/* API Key Management */
+.api-key-create-form {
+  margin-bottom: 1rem;
+}
+
+.api-key-create-inputs {
+  display: flex;
+  gap: 0.5rem;
+  align-items: stretch;
+}
+
+.api-key-create-inputs .settings-input {
+  flex: 1;
+  min-width: 0;
+}
+
+.api-key-expiry-select {
+  flex: 0 0 auto !important;
+  width: auto !important;
+  min-width: 120px;
+}
+
+.btn-create-key {
+  flex-shrink: 0;
+  padding: 0.625rem 1.25rem;
+  background: var(--accent-color);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: inherit;
+  white-space: nowrap;
+}
+
+.btn-create-key:hover {
+  background: var(--accent-hover);
+  transform: translateY(-1px);
+}
+
+.api-key-error {
+  color: #d32f2f;
+  font-size: 0.8125rem;
+  margin: 0.5rem 0 0;
+}
+
+.api-key-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.api-key-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  background: var(--bg-secondary);
+  border-radius: 8px;
+  gap: 0.75rem;
+}
+
+.api-key-item-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.api-key-item-name {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.api-key-item-meta {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.btn-revoke-key {
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  padding: 6px;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--text-secondary);
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.btn-revoke-key:hover {
+  background: rgba(211, 47, 47, 0.1);
+  color: #d32f2f;
+}
+
+.api-key-created-value {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.btn-copy-key {
+  flex-shrink: 0;
+  padding: 0.375rem 0.75rem;
+  background: var(--accent-color);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: inherit;
+  margin-top: 0.5rem;
+}
+
+.btn-copy-key:hover {
+  background: var(--accent-hover);
+}
+
+.btn-dismiss-key {
+  display: block;
+  width: 100%;
+  margin-top: 0.75rem;
+  padding: 0.5rem;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  font-size: 0.8125rem;
+  color: var(--text-primary);
+  cursor: pointer;
+  font-family: inherit;
+  transition: all 0.2s ease;
+}
+
+.btn-dismiss-key:hover {
+  background: var(--bg-secondary);
+}
+
 /* Mobile */
 @media (max-width: 768px) {
   .settings-modal {
@@ -465,6 +612,14 @@ input:checked + .toggle-slider:before {
 
   .settings-item-control {
     align-self: flex-end;
+  }
+
+  .api-key-create-inputs {
+    flex-direction: column;
+  }
+
+  .api-key-expiry-select {
+    min-width: 0;
   }
 
   .settings-instructions ol {

--- a/client/src/constants/api.js
+++ b/client/src/constants/api.js
@@ -34,6 +34,12 @@ export const API_ENDPOINTS = {
     SEARCH: '/api/friends/search',
   },
 
+  // API Keys endpoints
+  API_KEYS: {
+    BASE: '/api/api-keys',
+    BY_ID: (id) => `/api/api-keys/${id}`,
+  },
+
   // Admin endpoints
   ADMIN: {
     USERS: '/api/admin/users',

--- a/client/src/services/api/apiKeysAPI.js
+++ b/client/src/services/api/apiKeysAPI.js
@@ -1,0 +1,31 @@
+import { fetchWithAuth } from './apiUtils';
+import { API_ENDPOINTS } from '../../constants/api';
+
+/**
+ * Get all API keys for the current user
+ */
+export async function getApiKeys() {
+  return fetchWithAuth(API_ENDPOINTS.API_KEYS.BASE);
+}
+
+/**
+ * Create a new API key
+ * @param {string} name - Descriptive name
+ * @param {string} expiresIn - '30d', '90d', '365d', or 'never'
+ */
+export async function createApiKey(name, expiresIn = 'never') {
+  return fetchWithAuth(API_ENDPOINTS.API_KEYS.BASE, {
+    method: 'POST',
+    body: JSON.stringify({ name, expiresIn }),
+  });
+}
+
+/**
+ * Revoke (delete) an API key
+ * @param {string} id - API key ID
+ */
+export async function revokeApiKey(id) {
+  return fetchWithAuth(API_ENDPOINTS.API_KEYS.BY_ID(id), {
+    method: 'DELETE',
+  });
+}

--- a/server/config/swagger.js
+++ b/server/config/swagger.js
@@ -1,0 +1,95 @@
+const swaggerJsdoc = require('swagger-jsdoc');
+
+const options = {
+  definition: {
+    openapi: '3.0.3',
+    info: {
+      title: 'KeepLocal API',
+      version: '1.0.0',
+      description: `
+## KeepLocal REST API
+
+Externe API für den Zugriff auf deine KeepLocal-Notizen von Scripts, Apps und Automatisierungen.
+
+### Authentifizierung
+
+Alle API-Endpunkte erfordern einen **API-Key**. Erstelle einen Key über die Web-Oberfläche unter Einstellungen → API-Keys, oder nutze den JWT-authentifizierten Endpunkt \`POST /api/api-keys\`.
+
+Sende den Key im \`X-API-Key\` Header:
+
+\`\`\`
+curl -H "X-API-Key: kl_dein_api_key_hier" https://dein-server/api/v1/notes
+\`\`\`
+
+### Rate Limiting
+
+- 500 Requests pro 15 Minuten pro IP
+- Bei Überschreitung: HTTP 429
+
+### Fehlerformat
+
+Alle Fehler folgen dem gleichen Format:
+\`\`\`json
+{
+  "success": false,
+  "error": "Fehlerbeschreibung"
+}
+\`\`\`
+`,
+      contact: {
+        name: 'KeepLocal',
+      },
+      license: {
+        name: 'MIT',
+      }
+    },
+    servers: [
+      {
+        url: '/',
+        description: 'Aktueller Server'
+      }
+    ],
+    components: {
+      securitySchemes: {
+        apiKeyAuth: {
+          type: 'apiKey',
+          in: 'header',
+          name: 'X-API-Key',
+          description: 'API-Key für externen Zugriff. Erstelle einen Key unter Einstellungen → API-Keys.'
+        },
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+          description: 'JWT-Token aus dem Login-Endpunkt'
+        }
+      }
+    },
+    tags: [
+      {
+        name: 'Notes',
+        description: 'Notizen erstellen, lesen, aktualisieren und löschen'
+      },
+      {
+        name: 'Tags',
+        description: 'Tags der eigenen Notizen abrufen'
+      },
+      {
+        name: 'User',
+        description: 'Benutzer-Profil'
+      },
+      {
+        name: 'API Keys',
+        description: 'API-Keys verwalten (erfordert JWT-Auth aus der Web-Oberfläche)'
+      }
+    ]
+  },
+  apis: [
+    './routes/v1/*.js',
+    './routes/apiKeys.js'
+  ]
+};
+
+const swaggerSpec = swaggerJsdoc(options);
+
+module.exports = swaggerSpec;

--- a/server/middleware/apiKeyAuth.js
+++ b/server/middleware/apiKeyAuth.js
@@ -1,0 +1,57 @@
+const ApiKey = require('../models/ApiKey');
+const User = require('../models/User');
+
+/**
+ * Authenticate requests via API key (X-API-Key header)
+ * Used for the external /api/v1/ endpoints
+ */
+const authenticateApiKey = async (req, res, next) => {
+  try {
+    const apiKey = req.headers['x-api-key'];
+
+    if (!apiKey) {
+      return res.status(401).json({
+        success: false,
+        error: 'API-Key erforderlich. Sende den Key im X-API-Key Header.'
+      });
+    }
+
+    // Look up the hashed key
+    const keyDoc = await ApiKey.findByKey(apiKey);
+
+    if (!keyDoc) {
+      return res.status(401).json({
+        success: false,
+        error: 'Ungültiger API-Key'
+      });
+    }
+
+    // Check expiration
+    if (keyDoc.expiresAt && keyDoc.expiresAt < new Date()) {
+      return res.status(401).json({
+        success: false,
+        error: 'API-Key abgelaufen'
+      });
+    }
+
+    // Load user
+    const user = await User.findById(keyDoc.userId).select('-password');
+    if (!user) {
+      return res.status(401).json({
+        success: false,
+        error: 'Benutzer nicht gefunden'
+      });
+    }
+
+    // Update last used timestamp (fire and forget)
+    ApiKey.updateOne({ _id: keyDoc._id }, { lastUsedAt: new Date() }).exec();
+
+    req.user = user;
+    req.apiKey = keyDoc;
+    next();
+  } catch (error) {
+    next(error);
+  }
+};
+
+module.exports = { authenticateApiKey };

--- a/server/middleware/errorHandler.js
+++ b/server/middleware/errorHandler.js
@@ -5,6 +5,15 @@ function errorHandler(err, req, res, next) {
   const statusCode = err.statusCode || err.status || 500;
   const message = err.message || 'Ein Serverfehler ist aufgetreten';
 
+  // Use consistent format for v1 API routes
+  if (req.originalUrl.startsWith('/api/v1')) {
+    return res.status(statusCode).json({
+      success: false,
+      error: message,
+      ...(process.env.NODE_ENV === 'development' && { stack: err.stack })
+    });
+  }
+
   res.status(statusCode).json({
     error: message,
     ...(process.env.NODE_ENV === 'development' && { stack: err.stack })

--- a/server/models/ApiKey.js
+++ b/server/models/ApiKey.js
@@ -1,0 +1,64 @@
+const mongoose = require('mongoose');
+const crypto = require('crypto');
+
+const apiKeySchema = new mongoose.Schema({
+  name: {
+    type: String,
+    required: [true, 'API-Key Name ist erforderlich'],
+    trim: true,
+    maxlength: 100
+  },
+  key: {
+    type: String,
+    required: true,
+    unique: true,
+    index: true
+  },
+  prefix: {
+    type: String,
+    required: true
+  },
+  userId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+    index: true
+  },
+  lastUsedAt: {
+    type: Date,
+    default: null
+  },
+  expiresAt: {
+    type: Date,
+    default: null // null = never expires
+  },
+  isActive: {
+    type: Boolean,
+    default: true
+  }
+}, {
+  timestamps: true
+});
+
+/**
+ * Generate a new API key
+ * Returns the raw key (only shown once) and the hashed version for storage
+ */
+apiKeySchema.statics.generateKey = function () {
+  const rawKey = `kl_${crypto.randomBytes(32).toString('hex')}`;
+  const hash = crypto.createHash('sha256').update(rawKey).digest('hex');
+  const prefix = rawKey.substring(0, 7);
+  return { rawKey, hash, prefix };
+};
+
+/**
+ * Find API key by raw key value
+ */
+apiKeySchema.statics.findByKey = async function (rawKey) {
+  const hash = crypto.createHash('sha256').update(rawKey).digest('hex');
+  return this.findOne({ key: hash, isActive: true });
+};
+
+const ApiKey = mongoose.model('ApiKey', apiKeySchema);
+
+module.exports = ApiKey;

--- a/server/package.json
+++ b/server/package.json
@@ -32,6 +32,8 @@
     "mongoose": "^8.0.0",
     "multer": "^1.4.5-lts.1",
     "sharp": "^0.34.5",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.1",
     "uuid": "^9.0.1",
     "xss": "^1.0.14"
   },

--- a/server/routes/apiKeys.js
+++ b/server/routes/apiKeys.js
@@ -1,0 +1,168 @@
+/**
+ * API Key Management Routes
+ * Allows users to create, list, and revoke API keys for external API access
+ * These routes use JWT auth (from the web UI) to manage keys
+ */
+
+const express = require('express');
+const router = express.Router();
+const ApiKey = require('../models/ApiKey');
+const { authenticateToken } = require('../middleware/auth');
+
+// All routes require JWT authentication
+router.use(authenticateToken);
+
+/**
+ * @swagger
+ * /api/api-keys:
+ *   get:
+ *     summary: List all API keys for the current user
+ *     tags: [API Keys]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: List of API keys (without the actual key values)
+ */
+router.get('/', async (req, res, next) => {
+  try {
+    const keys = await ApiKey.find({ userId: req.user._id })
+      .select('-key')
+      .sort({ createdAt: -1 });
+
+    res.json({
+      success: true,
+      data: keys
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+/**
+ * @swagger
+ * /api/api-keys:
+ *   post:
+ *     summary: Create a new API key
+ *     tags: [API Keys]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [name]
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 description: A descriptive name for the key
+ *               expiresIn:
+ *                 type: string
+ *                 enum: [30d, 90d, 365d, never]
+ *                 default: never
+ *     responses:
+ *       201:
+ *         description: API key created. The key value is only returned once.
+ */
+router.post('/', async (req, res, next) => {
+  try {
+    const { name, expiresIn } = req.body;
+
+    if (!name || !name.trim()) {
+      return res.status(400).json({
+        success: false,
+        error: 'Name ist erforderlich'
+      });
+    }
+
+    // Limit keys per user
+    const existingCount = await ApiKey.countDocuments({ userId: req.user._id });
+    if (existingCount >= 10) {
+      return res.status(400).json({
+        success: false,
+        error: 'Maximal 10 API-Keys pro Benutzer erlaubt'
+      });
+    }
+
+    const { rawKey, hash, prefix } = ApiKey.generateKey();
+
+    // Calculate expiration
+    let expiresAt = null;
+    if (expiresIn && expiresIn !== 'never') {
+      const days = parseInt(expiresIn);
+      if (!isNaN(days) && days > 0) {
+        expiresAt = new Date(Date.now() + days * 24 * 60 * 60 * 1000);
+      }
+    }
+
+    const apiKey = new ApiKey({
+      name: name.trim(),
+      key: hash,
+      prefix,
+      userId: req.user._id,
+      expiresAt
+    });
+
+    await apiKey.save();
+
+    res.status(201).json({
+      success: true,
+      data: {
+        id: apiKey._id,
+        name: apiKey.name,
+        key: rawKey, // Only returned once!
+        prefix: apiKey.prefix,
+        expiresAt: apiKey.expiresAt,
+        createdAt: apiKey.createdAt
+      },
+      message: 'API-Key erstellt. Speichere den Key sicher - er wird nur einmal angezeigt!'
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+/**
+ * @swagger
+ * /api/api-keys/{id}:
+ *   delete:
+ *     summary: Revoke (delete) an API key
+ *     tags: [API Keys]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: API key revoked
+ */
+router.delete('/:id', async (req, res, next) => {
+  try {
+    const key = await ApiKey.findOneAndDelete({
+      _id: req.params.id,
+      userId: req.user._id
+    });
+
+    if (!key) {
+      return res.status(404).json({
+        success: false,
+        error: 'API-Key nicht gefunden'
+      });
+    }
+
+    res.json({
+      success: true,
+      message: 'API-Key widerrufen'
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+module.exports = router;

--- a/server/routes/v1/index.js
+++ b/server/routes/v1/index.js
@@ -1,0 +1,18 @@
+/**
+ * API v1 Router
+ * Mounts all v1 sub-routes with API key authentication
+ */
+
+const express = require('express');
+const router = express.Router();
+const { authenticateApiKey } = require('../../middleware/apiKeyAuth');
+
+// All v1 routes require API key authentication
+router.use(authenticateApiKey);
+
+// Mount sub-routes
+router.use('/notes', require('./notes'));
+router.use('/tags', require('./tags'));
+router.use('/user', require('./user'));
+
+module.exports = router;

--- a/server/routes/v1/notes.js
+++ b/server/routes/v1/notes.js
@@ -1,0 +1,569 @@
+/**
+ * API v1 - Notes Routes
+ * External REST API for notes, authenticated via API key
+ */
+
+const express = require('express');
+const router = express.Router();
+const { notesService } = require('../../services');
+const { httpStatus } = require('../../constants');
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     Note:
+ *       type: object
+ *       properties:
+ *         _id:
+ *           type: string
+ *           example: "507f1f77bcf86cd799439011"
+ *         title:
+ *           type: string
+ *           example: "Einkaufsliste"
+ *         content:
+ *           type: string
+ *           example: "Milch, Brot, Eier"
+ *         color:
+ *           type: string
+ *           enum: ["#ffffff","#f28b82","#fbbc04","#fff475","#ccff90","#a7ffeb","#cbf0f8","#aecbfa","#d7aefb","#fdcfe8","#e6c9a8","#e8eaed"]
+ *           example: "#ffffff"
+ *         isPinned:
+ *           type: boolean
+ *         isArchived:
+ *           type: boolean
+ *         tags:
+ *           type: array
+ *           items:
+ *             type: string
+ *           example: ["einkauf", "wichtig"]
+ *         isTodoList:
+ *           type: boolean
+ *         todoItems:
+ *           type: array
+ *           items:
+ *             type: object
+ *             properties:
+ *               text:
+ *                 type: string
+ *               completed:
+ *                 type: boolean
+ *               order:
+ *                 type: number
+ *         images:
+ *           type: array
+ *           items:
+ *             type: object
+ *             properties:
+ *               url:
+ *                 type: string
+ *               filename:
+ *                 type: string
+ *               thumbnailUrl:
+ *                 type: string
+ *         createdAt:
+ *           type: string
+ *           format: date-time
+ *         updatedAt:
+ *           type: string
+ *           format: date-time
+ *     NoteInput:
+ *       type: object
+ *       properties:
+ *         title:
+ *           type: string
+ *           maxLength: 200
+ *           example: "Einkaufsliste"
+ *         content:
+ *           type: string
+ *           maxLength: 10000
+ *           example: "Milch, Brot, Eier"
+ *         color:
+ *           type: string
+ *           enum: ["#ffffff","#f28b82","#fbbc04","#fff475","#ccff90","#a7ffeb","#cbf0f8","#aecbfa","#d7aefb","#fdcfe8","#e6c9a8","#e8eaed"]
+ *         isPinned:
+ *           type: boolean
+ *           default: false
+ *         tags:
+ *           type: array
+ *           items:
+ *             type: string
+ *         isTodoList:
+ *           type: boolean
+ *           default: false
+ *         todoItems:
+ *           type: array
+ *           items:
+ *             type: object
+ *             required: [text]
+ *             properties:
+ *               text:
+ *                 type: string
+ *               completed:
+ *                 type: boolean
+ *               order:
+ *                 type: number
+ *     ApiResponse:
+ *       type: object
+ *       properties:
+ *         success:
+ *           type: boolean
+ *         data:
+ *           type: object
+ *         error:
+ *           type: string
+ *     PaginatedNotes:
+ *       type: object
+ *       properties:
+ *         success:
+ *           type: boolean
+ *         data:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/Note'
+ *         pagination:
+ *           type: object
+ *           properties:
+ *             page:
+ *               type: integer
+ *             limit:
+ *               type: integer
+ *             total:
+ *               type: integer
+ *             pages:
+ *               type: integer
+ */
+
+/**
+ * @swagger
+ * /api/v1/notes:
+ *   get:
+ *     summary: Alle Notizen abrufen
+ *     description: Gibt alle eigenen und geteilten Notizen zurück, mit optionaler Suche, Tag-Filter und Paginierung.
+ *     tags: [Notes]
+ *     security:
+ *       - apiKeyAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: search
+ *         schema:
+ *           type: string
+ *         description: Volltextsuche in Titel und Inhalt
+ *       - in: query
+ *         name: tag
+ *         schema:
+ *           type: string
+ *         description: Nach Tag filtern
+ *       - in: query
+ *         name: archived
+ *         schema:
+ *           type: string
+ *           enum: ["true", "false"]
+ *           default: "false"
+ *         description: Archivierte Notizen anzeigen
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           default: 1
+ *         description: Seitennummer
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 50
+ *           maximum: 100
+ *         description: Einträge pro Seite
+ *     responses:
+ *       200:
+ *         description: Liste der Notizen
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/PaginatedNotes'
+ *       401:
+ *         description: Nicht authentifiziert
+ */
+router.get('/', async (req, res, next) => {
+  try {
+    const { search, tag, page, limit, archived } = req.query;
+
+    const result = await notesService.getAllNotes({
+      userId: req.user._id,
+      search,
+      tag,
+      page: page || 1,
+      limit: Math.min(parseInt(limit) || 50, 100),
+      archived: archived || 'false'
+    });
+
+    res.json({
+      success: true,
+      data: result.notes,
+      pagination: result.pagination
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+/**
+ * @swagger
+ * /api/v1/notes/{id}:
+ *   get:
+ *     summary: Einzelne Notiz abrufen
+ *     tags: [Notes]
+ *     security:
+ *       - apiKeyAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Notiz-ID
+ *     responses:
+ *       200:
+ *         description: Die Notiz
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 data:
+ *                   $ref: '#/components/schemas/Note'
+ *       404:
+ *         description: Notiz nicht gefunden
+ */
+router.get('/:id', async (req, res, next) => {
+  try {
+    const note = await notesService.getNoteById(req.params.id, req.user._id);
+    res.json({
+      success: true,
+      data: note
+    });
+  } catch (error) {
+    if (error.statusCode === 404 || error.kind === 'ObjectId') {
+      return res.status(httpStatus.NOT_FOUND).json({
+        success: false,
+        error: 'Notiz nicht gefunden'
+      });
+    }
+    next(error);
+  }
+});
+
+/**
+ * @swagger
+ * /api/v1/notes:
+ *   post:
+ *     summary: Neue Notiz erstellen
+ *     tags: [Notes]
+ *     security:
+ *       - apiKeyAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/NoteInput'
+ *           examples:
+ *             textNote:
+ *               summary: Einfache Textnotiz
+ *               value:
+ *                 title: "Meine Notiz"
+ *                 content: "Inhalt der Notiz"
+ *                 color: "#ffffff"
+ *                 tags: ["arbeit"]
+ *             todoNote:
+ *               summary: Todo-Liste
+ *               value:
+ *                 title: "Einkaufsliste"
+ *                 isTodoList: true
+ *                 todoItems:
+ *                   - text: "Milch"
+ *                     completed: false
+ *                   - text: "Brot"
+ *                     completed: true
+ *     responses:
+ *       201:
+ *         description: Notiz erstellt
+ *       400:
+ *         description: Ungültige Daten
+ */
+router.post('/', async (req, res, next) => {
+  try {
+    const note = await notesService.createNote(req.body, req.user._id);
+    res.status(httpStatus.CREATED).json({
+      success: true,
+      data: note
+    });
+  } catch (error) {
+    if (error.name === 'ValidationError') {
+      return res.status(httpStatus.BAD_REQUEST).json({
+        success: false,
+        error: error.message
+      });
+    }
+    next(error);
+  }
+});
+
+/**
+ * @swagger
+ * /api/v1/notes/{id}:
+ *   put:
+ *     summary: Notiz aktualisieren
+ *     tags: [Notes]
+ *     security:
+ *       - apiKeyAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/NoteInput'
+ *     responses:
+ *       200:
+ *         description: Notiz aktualisiert
+ *       404:
+ *         description: Notiz nicht gefunden
+ */
+router.put('/:id', async (req, res, next) => {
+  try {
+    const note = await notesService.updateNote(req.params.id, req.body, req.user._id);
+    res.json({
+      success: true,
+      data: note
+    });
+  } catch (error) {
+    if (error.statusCode === 404 || error.kind === 'ObjectId') {
+      return res.status(httpStatus.NOT_FOUND).json({
+        success: false,
+        error: 'Notiz nicht gefunden'
+      });
+    }
+    if (error.statusCode === 400 || error.name === 'ValidationError') {
+      return res.status(httpStatus.BAD_REQUEST).json({
+        success: false,
+        error: error.message
+      });
+    }
+    next(error);
+  }
+});
+
+/**
+ * @swagger
+ * /api/v1/notes/{id}:
+ *   delete:
+ *     summary: Notiz löschen
+ *     tags: [Notes]
+ *     security:
+ *       - apiKeyAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Notiz gelöscht
+ *       404:
+ *         description: Notiz nicht gefunden
+ */
+router.delete('/:id', async (req, res, next) => {
+  try {
+    await notesService.deleteNote(req.params.id, req.user._id);
+    res.json({
+      success: true,
+      message: 'Notiz gelöscht'
+    });
+  } catch (error) {
+    if (error.statusCode === 404 || error.kind === 'ObjectId') {
+      return res.status(httpStatus.NOT_FOUND).json({
+        success: false,
+        error: 'Notiz nicht gefunden'
+      });
+    }
+    next(error);
+  }
+});
+
+/**
+ * @swagger
+ * /api/v1/notes/{id}/pin:
+ *   post:
+ *     summary: Pin-Status umschalten
+ *     tags: [Notes]
+ *     security:
+ *       - apiKeyAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Pin-Status geändert
+ */
+router.post('/:id/pin', async (req, res, next) => {
+  try {
+    const note = await notesService.togglePinNote(req.params.id, req.user._id);
+    res.json({
+      success: true,
+      data: note
+    });
+  } catch (error) {
+    if (error.statusCode === 404 || error.kind === 'ObjectId') {
+      return res.status(httpStatus.NOT_FOUND).json({
+        success: false,
+        error: 'Notiz nicht gefunden'
+      });
+    }
+    next(error);
+  }
+});
+
+/**
+ * @swagger
+ * /api/v1/notes/{id}/archive:
+ *   post:
+ *     summary: Archiv-Status umschalten
+ *     tags: [Notes]
+ *     security:
+ *       - apiKeyAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Archiv-Status geändert
+ */
+router.post('/:id/archive', async (req, res, next) => {
+  try {
+    const note = await notesService.toggleArchiveNote(req.params.id, req.user._id);
+    res.json({
+      success: true,
+      data: note
+    });
+  } catch (error) {
+    if (error.statusCode === 404 || error.kind === 'ObjectId') {
+      return res.status(httpStatus.NOT_FOUND).json({
+        success: false,
+        error: 'Notiz nicht gefunden'
+      });
+    }
+    next(error);
+  }
+});
+
+/**
+ * @swagger
+ * /api/v1/notes/{id}/share:
+ *   post:
+ *     summary: Notiz mit einem Benutzer teilen
+ *     tags: [Notes]
+ *     security:
+ *       - apiKeyAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [userId]
+ *             properties:
+ *               userId:
+ *                 type: string
+ *                 description: ID des Benutzers, mit dem geteilt werden soll
+ *     responses:
+ *       200:
+ *         description: Notiz geteilt
+ */
+router.post('/:id/share', async (req, res, next) => {
+  try {
+    const { userId: targetUserId } = req.body;
+    if (!targetUserId) {
+      return res.status(httpStatus.BAD_REQUEST).json({
+        success: false,
+        error: 'userId ist erforderlich'
+      });
+    }
+    const note = await notesService.shareNote(req.params.id, req.user._id, targetUserId);
+    res.json({
+      success: true,
+      data: note
+    });
+  } catch (error) {
+    if (error.statusCode === 404 || error.kind === 'ObjectId') {
+      return res.status(httpStatus.NOT_FOUND).json({
+        success: false,
+        error: 'Notiz oder Benutzer nicht gefunden'
+      });
+    }
+    next(error);
+  }
+});
+
+/**
+ * @swagger
+ * /api/v1/notes/{id}/share/{userId}:
+ *   delete:
+ *     summary: Notiz-Freigabe für einen Benutzer aufheben
+ *     tags: [Notes]
+ *     security:
+ *       - apiKeyAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Freigabe aufgehoben
+ */
+router.delete('/:id/share/:userId', async (req, res, next) => {
+  try {
+    const note = await notesService.unshareNote(req.params.id, req.user._id, req.params.userId);
+    res.json({
+      success: true,
+      data: note
+    });
+  } catch (error) {
+    if (error.statusCode === 404 || error.kind === 'ObjectId') {
+      return res.status(httpStatus.NOT_FOUND).json({
+        success: false,
+        error: 'Notiz nicht gefunden'
+      });
+    }
+    next(error);
+  }
+});
+
+module.exports = router;

--- a/server/routes/v1/tags.js
+++ b/server/routes/v1/tags.js
@@ -1,0 +1,87 @@
+/**
+ * API v1 - Tags Routes
+ * External REST API for tag operations
+ */
+
+const express = require('express');
+const router = express.Router();
+const Note = require('../../models/Note');
+
+/**
+ * @swagger
+ * /api/v1/tags:
+ *   get:
+ *     summary: Alle Tags des Benutzers abrufen
+ *     description: Gibt eine sortierte Liste aller Tags zurück, die der Benutzer in seinen Notizen verwendet, inklusive Anzahl.
+ *     tags: [Tags]
+ *     security:
+ *       - apiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: Liste der Tags mit Anzahl
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       tag:
+ *                         type: string
+ *                         example: "arbeit"
+ *                       count:
+ *                         type: integer
+ *                         example: 5
+ *             example:
+ *               success: true
+ *               data:
+ *                 - tag: "arbeit"
+ *                   count: 12
+ *                 - tag: "privat"
+ *                   count: 8
+ *                 - tag: "einkauf"
+ *                   count: 3
+ */
+router.get('/', async (req, res, next) => {
+  try {
+    const tags = await Note.aggregate([
+      {
+        $match: {
+          $or: [
+            { userId: req.user._id },
+            { sharedWith: req.user._id }
+          ]
+        }
+      },
+      { $unwind: '$tags' },
+      {
+        $group: {
+          _id: '$tags',
+          count: { $sum: 1 }
+        }
+      },
+      { $sort: { count: -1 } },
+      {
+        $project: {
+          _id: 0,
+          tag: '$_id',
+          count: 1
+        }
+      }
+    ]);
+
+    res.json({
+      success: true,
+      data: tags
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+module.exports = router;

--- a/server/routes/v1/user.js
+++ b/server/routes/v1/user.js
@@ -1,0 +1,70 @@
+/**
+ * API v1 - User Routes
+ * External REST API for user profile info
+ */
+
+const express = require('express');
+const router = express.Router();
+const Note = require('../../models/Note');
+
+/**
+ * @swagger
+ * /api/v1/user/me:
+ *   get:
+ *     summary: Eigenes Profil abrufen
+ *     description: Gibt Informationen zum authentifizierten Benutzer zurück.
+ *     tags: [User]
+ *     security:
+ *       - apiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: Benutzerinformationen
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                     username:
+ *                       type: string
+ *                     email:
+ *                       type: string
+ *                     isAdmin:
+ *                       type: boolean
+ *                     createdAt:
+ *                       type: string
+ *                       format: date-time
+ */
+router.get('/me', async (req, res, next) => {
+  try {
+    // Get note count for the user
+    const noteCount = await Note.countDocuments({
+      $or: [
+        { userId: req.user._id },
+        { sharedWith: req.user._id }
+      ]
+    });
+
+    res.json({
+      success: true,
+      data: {
+        id: req.user._id,
+        username: req.user.username,
+        email: req.user.email,
+        isAdmin: req.user.isAdmin,
+        noteCount,
+        createdAt: req.user.createdAt
+      }
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
This PR introduces a complete API Key management system and a new external REST API (v1) for programmatic access to KeepLocal notes. Users can now create, manage, and revoke API keys through the settings UI, and external applications can authenticate using these keys to access notes via documented REST endpoints.

## Key Changes

### Frontend (Client)
- **API Key Management UI** in Settings component with ability to:
  - Create new API keys with optional expiration (30/90/365 days or never)
  - View all created keys with metadata (creation date, last used, expiration)
  - Revoke/delete keys with one-click action
  - Copy newly created keys (shown only once with warning)
- **New CSS styles** for API key forms, lists, and buttons with responsive mobile layout
- **New API service** (`apiKeysAPI.js`) for managing keys via authenticated endpoints

### Backend (Server)
- **API Key Model** (`ApiKey.js`) with:
  - Secure key generation and hashing (SHA-256)
  - Expiration support
  - Last used tracking
  - Prefix display for key identification
- **API Key Routes** (`/api/api-keys`) for CRUD operations (JWT-authenticated)
- **API Key Middleware** (`apiKeyAuth.js`) for authenticating external API requests
- **External REST API v1** with three sub-routers:
  - **Notes** (`/api/v1/notes`): Full CRUD operations, pin/archive/share functionality
  - **Tags** (`/api/v1/tags`): List all tags with counts
  - **User** (`/api/v1/user/me`): Profile and note count info
- **Swagger/OpenAPI Documentation** at `/api/docs` with:
  - Complete endpoint documentation
  - Request/response schemas
  - Authentication examples
  - Rate limiting info
- **Error Handler Enhancement** for consistent v1 API error responses
- **Dependencies**: Added `swagger-jsdoc` and `swagger-ui-express`

### Security Features
- API keys are hashed before storage (never stored in plaintext)
- Keys are only returned once during creation
- Expiration validation on each request
- Separate authentication for external API (API key) vs internal UI (JWT)
- CSRF protection maintained for web UI endpoints

### API Endpoints
- `GET/POST /api/api-keys` - List and create keys (JWT auth)
- `DELETE /api/api-keys/{id}` - Revoke key (JWT auth)
- `GET/POST /api/v1/notes` - List and create notes (API key auth)
- `GET/PUT/DELETE /api/v1/notes/{id}` - Note operations (API key auth)
- `POST /api/v1/notes/{id}/pin|archive|share` - Note actions (API key auth)
- `GET /api/v1/tags` - List tags (API key auth)
- `GET /api/v1/user/me` - User profile (API key auth)
- `GET /api/docs` - Interactive API documentation

## Implementation Details
- Keys use format `kl_<random>` for easy identification
- Prefix stored separately for display without exposing full key
- Pagination support on notes endpoint (max 100 items per page)
- All v1 endpoints return consistent `{success, data, error}` format
- German language strings throughout for consistency with existing UI
- Mobile-responsive API key management UI

https://claude.ai/code/session_016pRHvvQEVD3HkkyyYrskbS