### PR TITLE
[codex] Fix note modal focus frames

### DIFF
--- a/client/public/service-worker.js
+++ b/client/public/service-worker.js
@@ -1,13 +1,27 @@
-const CACHE_NAME = 'keeplocal-v1';
+const CACHE_NAME = 'keeplocal-v2';
 const urlsToCache = [
   '/',
   '/index.html',
-  '/static/css/main.css',
-  '/static/js/main.js',
   '/manifest.json',
   '/icon-192.png',
   '/icon-512.png'
 ];
+
+function cacheResponse(request, response) {
+  if (!response || response.status !== 200 || response.type !== 'basic') {
+    return response;
+  }
+
+  caches.open(CACHE_NAME)
+    .then(cache => {
+      cache.put(request, response.clone());
+    })
+    .catch(err => {
+      console.log('Cache put skipped:', err.message);
+    });
+
+  return response;
+}
 
 // Install event - cache resources
 self.addEventListener('install', event => {
@@ -43,7 +57,7 @@ self.addEventListener('activate', event => {
   self.clients.claim();
 });
 
-// Fetch event - serve from cache, fallback to network
+// Fetch event - serve app shell from network first, assets from cache first
 self.addEventListener('fetch', event => {
   // Skip non-GET requests
   if (event.request.method !== 'GET') {
@@ -73,7 +87,16 @@ self.addEventListener('fetch', event => {
     return;
   }
 
-  // For other requests, try cache first, then network
+  if (event.request.mode === 'navigate' || url.pathname === '/' || url.pathname === '/index.html') {
+    event.respondWith(
+      fetch(event.request)
+        .then(response => cacheResponse(event.request, response))
+        .catch(() => caches.match(event.request).then(response => response || caches.match('/index.html')))
+    );
+    return;
+  }
+
+  // Hashed static assets can be served cache first.
   event.respondWith(
     caches.match(event.request)
       .then(response => {
@@ -81,38 +104,7 @@ self.addEventListener('fetch', event => {
           return response;
         }
 
-        return fetch(event.request).then(response => {
-          // Don't cache non-successful responses or opaque responses
-          if (!response || response.status !== 200 || response.type !== 'basic') {
-            return response;
-          }
-
-          // Only cache http/https requests
-          const requestUrl = new URL(event.request.url);
-          if (!requestUrl.protocol.startsWith('http')) {
-            return response;
-          }
-
-          // Clone the response
-          const responseToCache = response.clone();
-
-          caches.open(CACHE_NAME)
-            .then(cache => {
-              cache.put(event.request, responseToCache);
-            })
-            .catch(err => {
-              // Silently ignore cache errors (e.g., for extension requests)
-              console.log('Cache put skipped:', err.message);
-            });
-
-          return response;
-        });
-      })
-      .catch(() => {
-        // Return offline page for navigation requests
-        if (event.request.mode === 'navigate') {
-          return caches.match('/index.html');
-        }
+        return fetch(event.request).then(response => cacheResponse(event.request, response));
       })
   );
 });

--- a/client/src/components/NoteModal.css
+++ b/client/src/components/NoteModal.css
@@ -115,7 +115,12 @@
 }
 
 .note-modal-title:focus {
-  border-bottom-color: var(--accent-color);
+  border-bottom-color: transparent;
+}
+
+.note-modal-title:focus-visible {
+  outline: none;
+  box-shadow: none;
 }
 
 .note-modal-title::placeholder {
@@ -143,6 +148,11 @@
   padding: var(--space-2) 0;
   min-height: 120px;
   overflow: hidden;
+}
+
+.note-modal-content:focus-visible {
+  outline: none;
+  box-shadow: none;
 }
 
 .note-modal-content::placeholder {
@@ -1064,7 +1074,7 @@
 
 .eink-mode .note-modal-title {
   color: #000000;
-  border-bottom-color: #000000;
+  border-bottom-color: transparent;
   font-family: 'Georgia', 'Times New Roman', serif;
 }
 

--- a/client/tests/noteModalFocusStyles.test.js
+++ b/client/tests/noteModalFocusStyles.test.js
@@ -1,0 +1,43 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const css = fs.readFileSync(
+  path.join(__dirname, '../src/components/NoteModal.css'),
+  'utf8'
+);
+
+function declarationsFor(selector) {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = css.match(new RegExp(`${escapedSelector}\\s*\\{([^}]*)\\}`, 'm'));
+
+  assert.ok(match, `${selector} rule is missing`);
+  return match[1].replace(/\s+/g, ' ');
+}
+
+test('note modal title focus-visible does not render the global input focus frame', () => {
+  const declarations = declarationsFor('.note-modal-title:focus-visible');
+
+  assert.match(declarations, /outline:\s*none/);
+  assert.match(declarations, /box-shadow:\s*none/);
+});
+
+test('note modal title focus does not draw a visible underline', () => {
+  const declarations = declarationsFor('.note-modal-title:focus');
+
+  assert.match(declarations, /border-bottom-color:\s*transparent/);
+});
+
+test('e-ink mode does not force a visible note modal title underline', () => {
+  const declarations = declarationsFor('.eink-mode .note-modal-title');
+
+  assert.match(declarations, /border-bottom-color:\s*transparent/);
+});
+
+test('note modal content focus-visible does not render the global textarea focus frame', () => {
+  const declarations = declarationsFor('.note-modal-content:focus-visible');
+
+  assert.match(declarations, /outline:\s*none/);
+  assert.match(declarations, /box-shadow:\s*none/);
+});

--- a/client/tests/serviceWorkerCacheStrategy.test.js
+++ b/client/tests/serviceWorkerCacheStrategy.test.js
@@ -1,0 +1,29 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const serviceWorker = fs.readFileSync(
+  path.join(__dirname, '../public/service-worker.js'),
+  'utf8'
+);
+
+test('service worker uses network-first handling before generic cache lookup for navigations', () => {
+  const fetchHandlerIndex = serviceWorker.indexOf("self.addEventListener('fetch'");
+  const navigationIndex = serviceWorker.indexOf("event.request.mode === 'navigate'", fetchHandlerIndex);
+  const genericCacheLookupIndex = serviceWorker.indexOf('caches.match(event.request)', fetchHandlerIndex);
+
+  assert.notEqual(navigationIndex, -1, 'navigation branch is missing');
+  assert.notEqual(genericCacheLookupIndex, -1, 'generic cache lookup is missing');
+  assert.ok(
+    navigationIndex < genericCacheLookupIndex,
+    'navigation requests must be handled before the generic cache-first lookup'
+  );
+
+  const navigationBlock = serviceWorker.slice(navigationIndex, genericCacheLookupIndex);
+  assert.match(navigationBlock, /fetch\(event\.request\)/);
+});
+
+test('service worker cache name is bumped so old app-shell caches are discarded', () => {
+  assert.doesNotMatch(serviceWorker, /CACHE_NAME\s*=\s*['"]keeplocal-v1['"]/);
+});


### PR DESCRIPTION
## Summary
- Removes the global focus frame from the note modal title and content textarea.
- Prevents E-Ink mode from forcing a visible title underline.
- Updates the service worker cache version and handles navigations before the generic cache-first lookup so stale app shells are replaced.
- Adds regression tests for the modal focus CSS and service worker navigation cache behavior.

## Verification
- `node --test tests/*.test.js` in the deployed local project: 6/6 passed.
- `npm run build` in the deployed local project: successful, with existing ESLint warnings only.
- Docker image deployed for `keeplocal`: `sha256:24237ea0f6b0d52962f566ef444a101cef39a155d0a5f723daf6b4801ef9b553`, container healthy.
- Live CSS contains `.note-modal-title:focus-visible{box-shadow:none;outline:none}` and `.note-modal-content:focus-visible{box-shadow:none;outline:none}`.
- Cloned this PR branch and ran `node --test client/tests/*.test.js`: 6/6 passed.
