### PR TITLE
[codex] Suppress note modal focus frames on all text inputs

### DIFF
--- a/client/src/components/NoteModal.css
+++ b/client/src/components/NoteModal.css
@@ -261,6 +261,11 @@
   color: var(--text-muted);
 }
 
+.note-modal-tags-input:focus-visible {
+  outline: none;
+  box-shadow: none;
+}
+
 .dark-mode .note-modal-tags-input {
   color: rgba(255, 255, 255, 0.7);
 }
@@ -283,6 +288,11 @@
 
 .note-modal-tags::placeholder {
   color: var(--text-muted);
+}
+
+.note-modal-tags:focus-visible {
+  outline: none;
+  box-shadow: none;
 }
 
 .dark-mode .note-modal-tags {
@@ -573,6 +583,11 @@
 
 .todo-item-input::placeholder {
   color: var(--text-muted);
+}
+
+.todo-item-input:focus-visible {
+  outline: none;
+  box-shadow: none;
 }
 
 .dark-mode .todo-item-input {

--- a/client/tests/noteModalFocusStyles.test.js
+++ b/client/tests/noteModalFocusStyles.test.js
@@ -41,3 +41,18 @@ test('note modal content focus-visible does not render the global textarea focus
   assert.match(declarations, /outline:\s*none/);
   assert.match(declarations, /box-shadow:\s*none/);
 });
+
+test('all note modal text entry fields suppress the global focus frame', () => {
+  for (const selector of [
+    '.note-modal-title:focus-visible',
+    '.note-modal-content:focus-visible',
+    '.note-modal-tags-input:focus-visible',
+    '.note-modal-tags:focus-visible',
+    '.todo-item-input:focus-visible',
+  ]) {
+    const declarations = declarationsFor(selector);
+
+    assert.match(declarations, /outline:\s*none/, selector);
+    assert.match(declarations, /box-shadow:\s*none/, selector);
+  }
+});


### PR DESCRIPTION
## Summary
- Extends the note modal focus-frame fix to every text entry surface: title, body textarea, tag input, legacy tags input, and todo item input.
- Adds a regression test that asserts all note modal text entry selectors suppress the global `input/textarea:focus-visible` frame.

## Verification
- `node --test tests/*.test.js` in the deployed local project: 7/7 passed.
- `npm run build` in the deployed local project: successful, with existing ESLint warnings only.
- Docker image deployed for `keeplocal`: `sha256:1d5f36b5eec00e6f3f53be3b62842af0cbe1cb08f6672febd18f9de89365dfd4`, container healthy.
- Live CSS bundle `main.ba1efefe.css` contains focus-visible overrides for title, content, tag input, legacy tags input, and todo item input.
- Chromium computed-style check against the built CSS: all five focused text fields report `outlineStyle: none` and `boxShadow: none`.
- Fresh clone of this PR branch: `node --test client/tests/*.test.js` passed 7/7.
