### PR TITLE
[codex] add doodle theme

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import './App.css';
+import './DoodleTheme.css';
 import NoteForm from './components/NoteForm';
 import NoteList from './components/NoteList';
 import SearchBar from './components/SearchBar';
@@ -37,7 +38,7 @@ function AppContent() {
   const [operationLoading, setOperationLoading] = useState({});
   const [theme, setTheme] = useState(() => {
     const savedTheme = localStorage.getItem('theme');
-    return savedTheme || 'light'; // 'light', 'dark', 'oled', or 'eink'
+    return savedTheme || 'light'; // 'light', 'dark', 'oled', 'eink', or 'doodle'
   });
   const [draggedNoteId, setDraggedNoteId] = useState(null);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
@@ -63,7 +64,7 @@ function AppContent() {
   // Theme anwenden
   useEffect(() => {
     // Remove all theme classes
-    document.body.classList.remove('dark-mode', 'oled-mode', 'eink-mode');
+    document.body.classList.remove('dark-mode', 'oled-mode', 'eink-mode', 'doodle-mode');
 
     // Add appropriate theme class
     if (theme === 'dark') {
@@ -72,6 +73,8 @@ function AppContent() {
       document.body.classList.add('oled-mode');
     } else if (theme === 'eink') {
       document.body.classList.add('eink-mode');
+    } else if (theme === 'doodle') {
+      document.body.classList.add('doodle-mode');
     }
 
     localStorage.setItem('theme', theme);
@@ -282,11 +285,13 @@ function AppContent() {
 
   // Theme umschalten
   const toggleTheme = () => {
-    // Cycle through themes: light -> dark -> oled -> eink -> light
+    // Cycle through themes: light -> dark -> oled -> eink -> doodle -> light
     setTheme(prevTheme => {
       if (prevTheme === 'light') return 'dark';
       if (prevTheme === 'dark') return 'oled';
       if (prevTheme === 'oled') return 'eink';
+      if (prevTheme === 'eink') return 'doodle';
+      if (prevTheme === 'doodle') return 'light';
       return 'light';
     });
   };

--- a/client/src/DoodleTheme.css
+++ b/client/src/DoodleTheme.css
@@ -1,0 +1,156 @@
+@import url('https://fonts.googleapis.com/css2?family=Delius+Swash+Caps&family=JetBrains+Mono:wght@400;500;600;700&display=swap');
+
+/* ============================================
+   Doodle Theme - Hand-drawn Studio
+   ============================================ */
+body.doodle-mode {
+  --font-display: 'Delius Swash Caps', 'Comic Sans MS', cursive;
+  --font-body: 'Delius Swash Caps', 'Comic Sans MS', cursive;
+  --font-mono: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-6: 24px;
+  --space-8: 32px;
+
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 8px;
+  --radius-xl: 8px;
+  --radius-2xl: 8px;
+
+  --bg-primary: #F8FCFF;
+  --bg-secondary: #FFFFFF;
+  --bg-tertiary: #EAF7FD;
+  --bg-elevated: #FFFFFF;
+  --bg-overlay: rgba(17, 24, 39, 0.35);
+  --bg-paper: #FFFFFF;
+  --bg-canvas: #F8FCFF;
+
+  --text-primary: #111827;
+  --text-secondary: #263D5B;
+  --text-tertiary: #4B5563;
+  --text-muted: #6B7280;
+  --text-inverse: #FFFFFF;
+
+  --border-color: rgba(38, 61, 91, 0.28);
+  --border-color-strong: #263D5B;
+  --border-focus: #49B6E5;
+
+  --accent-color: #263D5B;
+  --accent-hover: #1D2F48;
+  --accent-active: #142239;
+  --accent-light: rgba(73, 182, 229, 0.18);
+  --accent-lighter: rgba(73, 182, 229, 0.08);
+
+  --accent-secondary: #49B6E5;
+  --accent-secondary-light: rgba(73, 182, 229, 0.22);
+
+  --success-color: #16A34A;
+  --success-light: rgba(22, 163, 74, 0.14);
+  --warning-color: #D97706;
+  --warning-light: rgba(217, 119, 6, 0.15);
+  --error-color: #DC2626;
+  --error-light: rgba(220, 38, 38, 0.13);
+  --info-color: #263D5B;
+  --info-light: rgba(73, 182, 229, 0.18);
+
+  --shadow-xs: 2px 2px 0 rgba(38, 61, 91, 0.12);
+  --shadow-sm: 3px 3px 0 rgba(38, 61, 91, 0.14);
+  --shadow-md: 4px 4px 0 rgba(38, 61, 91, 0.16);
+  --shadow-lg: 5px 5px 0 rgba(38, 61, 91, 0.18);
+  --shadow-xl: 7px 7px 0 rgba(38, 61, 91, 0.2);
+  --shadow-2xl: 9px 9px 0 rgba(38, 61, 91, 0.22);
+  --shadow-focus: 0 0 0 3px rgba(73, 182, 229, 0.35), 3px 3px 0 rgba(38, 61, 91, 0.22);
+  --shadow-paper: 4px 4px 0 rgba(38, 61, 91, 0.16);
+  --shadow-lifted: 7px 7px 0 rgba(38, 61, 91, 0.2);
+
+  --hover-overlay: rgba(73, 182, 229, 0.12);
+  --active-overlay: rgba(38, 61, 91, 0.14);
+  --selected-overlay: rgba(73, 182, 229, 0.22);
+
+  --header-bg: #49B6E5;
+  --header-text: #111827;
+
+  --note-white: #FFFFFF;
+  --note-red: #FFE2E2;
+  --note-orange: #FFE8CC;
+  --note-yellow: #FFF6BF;
+  --note-green: #DCFCE7;
+  --note-teal: #CCFBF1;
+  --note-cyan: #D8F3FF;
+  --note-blue: #DBEAFE;
+  --note-purple: #EDE9FE;
+  --note-pink: #FCE7F3;
+  --note-brown: #F1E3D3;
+  --note-gray: #F3F4F6;
+}
+
+body.doodle-mode::before {
+  background-image:
+    linear-gradient(rgba(73, 182, 229, 0.13) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(73, 182, 229, 0.13) 1px, transparent 1px);
+  background-size: 28px 28px;
+  opacity: 1;
+}
+
+body.doodle-mode .note,
+body.doodle-mode .note-modal,
+body.doodle-mode .sidebar,
+body.doodle-mode .settings-modal,
+body.doodle-mode .auth-box,
+body.doodle-mode .toast {
+  border: 2px solid var(--border-color-strong);
+  border-radius: var(--radius-md);
+  box-shadow: 4px 4px 0 rgba(38, 61, 91, 0.16);
+}
+
+body.doodle-mode button,
+body.doodle-mode input,
+body.doodle-mode textarea,
+body.doodle-mode select {
+  border-radius: var(--radius-md);
+}
+
+body.doodle-mode input,
+body.doodle-mode textarea,
+body.doodle-mode select {
+  border-color: var(--border-color-strong);
+}
+
+body.doodle-mode .note:hover,
+body.doodle-mode .user-name.clickable:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 6px 6px 0 rgba(38, 61, 91, 0.18);
+}
+
+body.doodle-mode .note-tag,
+body.doodle-mode .tag-pill {
+  border: 1px dashed var(--border-color-strong);
+}
+
+body.doodle-mode .btn-primary,
+body.doodle-mode .btn-secondary,
+body.doodle-mode .auth-button {
+  border: 2px solid var(--border-color-strong);
+  box-shadow: 3px 3px 0 rgba(38, 61, 91, 0.18);
+}
+
+.doodle-mode .App-header {
+  border-bottom: 2px solid var(--border-color-strong);
+  box-shadow: 0 3px 0 rgba(38, 61, 91, 0.22);
+}
+
+.doodle-mode .App-header::after {
+  height: 4px;
+  background: repeating-linear-gradient(
+    90deg,
+    #263D5B 0 18px,
+    #FFFFFF 18px 24px,
+    #D97706 24px 36px,
+    #FFFFFF 36px 42px
+  );
+  opacity: 1;
+}

--- a/client/src/components/ThemeToggle.js
+++ b/client/src/components/ThemeToggle.js
@@ -10,13 +10,17 @@ function ThemeToggle({ theme, onToggle }) {
     if (theme === 'light') return '☀️'; // Currently light mode
     if (theme === 'dark') return '🌙'; // Currently dark mode
     if (theme === 'oled') return '⚫'; // Currently OLED mode
-    return '📰'; // Currently E-Ink mode
+    if (theme === 'eink') return '📰'; // Currently E-Ink mode
+    if (theme === 'doodle') return '✏️'; // Currently Doodle mode
+    return '☀️';
   };
 
   const getThemeTitle = () => {
     if (theme === 'light') return t('switchToDarkMode');
     if (theme === 'dark') return t('switchToOledMode');
     if (theme === 'oled') return t('switchToEinkMode');
+    if (theme === 'eink') return t('switchToDoodleMode');
+    if (theme === 'doodle') return t('switchToLightMode');
     return t('switchToLightMode');
   };
 
@@ -25,7 +29,7 @@ function ThemeToggle({ theme, onToggle }) {
       className="theme-toggle"
       onClick={onToggle}
       title={getThemeTitle()}
-      aria-label="Toggle theme"
+      aria-label={getThemeTitle()}
     >
       {getThemeIcon()}
     </button>

--- a/client/src/translations/de.js
+++ b/client/src/translations/de.js
@@ -149,6 +149,7 @@ export const de = {
   switchToDarkMode: 'Zum dunklen Modus wechseln',
   switchToOledMode: 'Zum OLED-Modus wechseln',
   switchToEinkMode: 'Zum E-Ink-Modus wechseln',
+  switchToDoodleMode: 'Zum Doodle-Modus wechseln',
   switchToNote: 'Zu Notiz wechseln',
   switchToList: 'Zu Liste wechseln',
 

--- a/client/src/translations/en.js
+++ b/client/src/translations/en.js
@@ -149,6 +149,7 @@ export const en = {
   switchToDarkMode: 'Switch to dark mode',
   switchToOledMode: 'Switch to OLED mode',
   switchToEinkMode: 'Switch to E-Ink mode',
+  switchToDoodleMode: 'Switch to Doodle mode',
   switchToNote: 'Switch to note',
   switchToList: 'Switch to list',
 

--- a/client/tests/themeModes.test.js
+++ b/client/tests/themeModes.test.js
@@ -1,0 +1,57 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const clientRoot = path.join(__dirname, '..');
+
+function readClientFile(...parts) {
+  return fs.readFileSync(path.join(clientRoot, ...parts), 'utf8');
+}
+
+test('theme cycle includes doodle mode after e-ink and applies the body class', () => {
+  const app = readClientFile('src/App.js');
+
+  assert.match(app, /savedTheme \|\| 'light'; \/\/ 'light', 'dark', 'oled', 'eink', or 'doodle'/);
+  assert.match(app, /classList\.remove\('dark-mode', 'oled-mode', 'eink-mode', 'doodle-mode'\)/);
+  assert.match(app, /theme === 'doodle'/);
+  assert.match(app, /classList\.add\('doodle-mode'\)/);
+  assert.match(app, /prevTheme === 'eink'\) return 'doodle'/);
+  assert.match(app, /prevTheme === 'doodle'\) return 'light'/);
+});
+
+test('theme toggle exposes doodle as a first-class selectable theme', () => {
+  const toggle = readClientFile('src/components/ThemeToggle.js');
+  const en = readClientFile('src/translations/en.js');
+  const de = readClientFile('src/translations/de.js');
+
+  assert.match(toggle, /theme === 'doodle'/);
+  assert.match(toggle, /return '✏️'/);
+  assert.match(toggle, /theme === 'eink'\) return t\('switchToDoodleMode'\)/);
+  assert.match(toggle, /theme === 'doodle'\) return t\('switchToLightMode'\)/);
+  assert.match(en, /switchToDoodleMode:\s*'Switch to Doodle mode'/);
+  assert.match(de, /switchToDoodleMode:\s*'Zum Doodle-Modus wechseln'/);
+});
+
+test('doodle theme defines accessible doodle tokens and handwritten typography', () => {
+  const css = readClientFile('src/DoodleTheme.css');
+  const app = readClientFile('src/App.js');
+
+  assert.match(css, /family=Delius\+Swash\+Caps/);
+  assert.match(css, /family=JetBrains\+Mono/);
+  assert.match(app, /import '\.\/DoodleTheme\.css'/);
+  assert.match(css, /body\.doodle-mode\s*\{/);
+  assert.match(css, /--font-display:\s*'Delius Swash Caps'/);
+  assert.match(css, /--font-body:\s*'Delius Swash Caps'/);
+  assert.match(css, /--font-mono:\s*'JetBrains Mono'/);
+  assert.match(css, /--text-primary:\s*#111827/);
+  assert.match(css, /--border-focus:\s*#49B6E5/);
+  assert.match(css, /--accent-color:\s*#263D5B/);
+  assert.match(css, /--success-color:\s*#16A34A/);
+  assert.match(css, /--warning-color:\s*#D97706/);
+  assert.match(css, /--error-color:\s*#DC2626/);
+  assert.match(css, /body\.doodle-mode \.note/);
+  assert.match(css, /box-shadow:\s*4px 4px 0/);
+  assert.match(css, /body\.doodle-mode::before/);
+  assert.match(css, /\.doodle-mode \.App-header::after/);
+});


### PR DESCRIPTION
## Summary
- adds Doodle as a selectable theme after e-ink in the theme cycle
- adds Doodle theme body class handling, toggle icon/title/aria text, and en/de translations
- adds a dedicated DoodleTheme.css with Delius Swash Caps / JetBrains Mono, Doodle tokens, sketch borders, paper grid background, and header stripe
- keeps the NoteModal text-entry focus-frame fix in place for title, content, and tag inputs
- adds a regression test for Doodle theme registration and styling tokens

## Validation
- Actual app: `node --test tests/*.test.js` passed, 10/10 tests
- Actual app: `npm run build` passed; only existing ESLint warnings remain
- GitHub checkout: `node --test tests/*.test.js` passed, 10/10 tests
- GitHub checkout: `npm run build` passed; only existing ESLint warnings remain
- Docker image deployed: `sha256:8256cd1aec3b5f5f9271101bfef12a8edff1660420054c3fb33856c4d590fc12`
- Container `keeplocal` verified running and healthy
- Deployed CSS contains Doodle font imports and `body.doodle-mode`
- External endpoint still returns the expected auth redirect

Note: the repo checkout does not include `client/package-lock.json`, so dependencies were prepared with `npm install --no-audit --no-fund` before running the build checks.