### PR TITLE
Fix multi-architecture Whisper model build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -78,21 +78,34 @@ jobs:
   test-image:
     needs: build-and-push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture:
+          - amd64
+          - arm64
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Generate JWT Secret
         id: jwt
         run: echo "secret=$(openssl rand -base64 32)" >> $GITHUB_OUTPUT
 
-      - name: Pull and test Docker image
+      - name: Pull and run ${{ matrix.architecture }} Docker image
         run: |
-          docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
+          docker pull \
+            --platform "linux/${{ matrix.architecture }}" \
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
 
           docker run -d \
             --name keeplocal-test \
+            --platform "linux/${{ matrix.architecture }}" \
             -p 3000:80 \
             -e JWT_SECRET="${{ steps.jwt.outputs.secret }}" \
             -e ALLOWED_ORIGINS="http://localhost:3000" \
@@ -112,7 +125,7 @@ jobs:
       - name: Test health endpoint
         run: |
           echo "Testing health endpoint..."
-          max_attempts=10
+          max_attempts=36
           attempt=0
 
           while [ $attempt -lt $max_attempts ]; do

--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -18,7 +18,6 @@ COPY client/ ./
 # IMPORTANT: REACT_APP_API_URL must be empty because the client code already adds /api prefix
 ARG REACT_APP_API_URL=
 ARG VITE_API_URL=${REACT_APP_API_URL}
-ARG WHISPER_MODEL=tiny
 ENV VITE_API_URL=${VITE_API_URL}
 RUN npm run build
 
@@ -32,6 +31,8 @@ COPY server/ ./
 
 # Stage 3: Final All-in-One Image
 FROM ubuntu:22.04
+
+ARG WHISPER_MODEL=tiny
 
 # Prevent interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive

--- a/server/tests/deploymentSecurity.test.js
+++ b/server/tests/deploymentSecurity.test.js
@@ -87,3 +87,31 @@ test('application containers drop root privileges', () => {
   assert.doesNotMatch(aiDockerfile, /python3\\\n/);
   assert.doesNotMatch(aiDockerfile, /python3-pip\\\n/);
 });
+
+test('all-in-one image declares the Whisper model argument in its consuming stage', () => {
+  const dockerfile = fs.readFileSync(path.join(root, 'Dockerfile.allinone'), 'utf8');
+  const stages = dockerfile.split(/^FROM /m);
+  const clientStage = stages.find((stage) => stage.startsWith('node:22-alpine AS client-builder'));
+  const runtimeStage = stages.find((stage) => stage.startsWith('ubuntu:22.04'));
+
+  assert.ok(clientStage, 'client-builder stage should exist');
+  assert.ok(runtimeStage, 'Ubuntu runtime stage should exist');
+  assert.doesNotMatch(clientStage, /^ARG WHISPER_MODEL=/m);
+  assert.match(runtimeStage, /^ARG WHISPER_MODEL=tiny$/m);
+  assert.match(runtimeStage, /^ENV WHISPER_MODEL=\$\{WHISPER_MODEL\}/m);
+  assert.ok(
+    runtimeStage.indexOf('ARG WHISPER_MODEL=tiny')
+      < runtimeStage.indexOf('ENV WHISPER_MODEL=${WHISPER_MODEL}'),
+    'WHISPER_MODEL must be declared before it is expanded in the runtime stage',
+  );
+});
+
+test('published all-in-one image is smoke-tested on every built architecture', () => {
+  const workflow = fs.readFileSync(path.join(root, '.github/workflows/docker-build.yml'), 'utf8');
+  const testJob = workflow.match(/\n  test-image:\n([\s\S]*)/)?.[1] || '';
+
+  assert.match(testJob, /architecture:\n\s+- amd64\n\s+- arm64/);
+  assert.match(testJob, /uses: docker\/setup-qemu-action@v3/);
+  assert.match(testJob, /docker pull[\s\S]*?--platform "linux\/\$\{\{ matrix\.architecture \}\}"/);
+  assert.match(testJob, /docker run[\s\S]*?--platform "linux\/\$\{\{ matrix\.architecture \}\}"/);
+});


### PR DESCRIPTION
## What changed

- declare `WHISPER_MODEL` in the final Ubuntu stage that consumes it
- add deployment regression coverage for Docker build-argument scope
- smoke-test the published all-in-one image on both AMD64 and ARM64 under QEMU

## Root cause

Docker build arguments are stage-scoped. `WHISPER_MODEL` was declared in `client-builder`, but expanded in the separate final stage, so it became an empty string. The AMD64 Whisper preload failed with `ValueError: Invalid model size ''`; Buildx then canceled the still-running ARM64 APT stage.

## Impact

The all-in-one workflow can preload the configured Whisper model on both target architectures. Post-push health and WebUI checks now explicitly run each architecture instead of silently selecting AMD64.

## Verification

- backend: 39/39 tests
- client: 22/22 tests
- AI: 4/4 tests
- client lint and production build passed
- all three Compose variants render successfully
- workflow YAML parses successfully
- `git diff --check` clean

The authoritative multi-architecture build/push and runtime smoke tests will run after merge to `main`, matching the repository's current workflow trigger.