### PR TITLE
Move Whisper validation to architecture runtime tests

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -142,6 +142,26 @@ jobs:
           docker logs keeplocal-test
           exit 1
 
+      - name: Test AI health endpoint
+        run: |
+          echo "Testing AI health endpoint..."
+          max_attempts=60
+          attempt=0
+
+          while [ $attempt -lt $max_attempts ]; do
+            if docker exec keeplocal-test curl -f http://127.0.0.1:5001/health; then
+              echo "AI health check passed!"
+              exit 0
+            fi
+            attempt=$((attempt + 1))
+            echo "Attempt $attempt/$max_attempts failed, retrying in 5s..."
+            sleep 5
+          done
+
+          echo "AI health check failed after $max_attempts attempts"
+          docker logs keeplocal-test
+          exit 1
+
       - name: Test WebUI
         run: |
           echo "Testing WebUI..."

--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -101,7 +101,7 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 ENV WHISPER_MODEL=${WHISPER_MODEL} \
     HF_HOME=/var/lib/keeplocal-ai
 RUN su -s /bin/sh node -c \
-    "python3 -c \"import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8')\""
+    "python3 -c \"import os; from faster_whisper import download_model; download_model(os.environ['WHISPER_MODEL'])\""
 
 # Copy built client from builder
 COPY --from=client-builder /app/client/build /app/client/build

--- a/ai/Dockerfile
+++ b/ai/Dockerfile
@@ -41,7 +41,7 @@ USER keeplocal
 
 # Pre-download the model to bake it into the image (optional but recommended for speed)
 # This prevents downloading 75MB-1.5GB on every container start if the volume is missing
-RUN python3 -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8')"
+RUN python3 -c "import os; from faster_whisper import download_model; download_model(os.environ['WHISPER_MODEL'])"
 
 EXPOSE 5000
 

--- a/server/tests/deploymentSecurity.test.js
+++ b/server/tests/deploymentSecurity.test.js
@@ -114,4 +114,15 @@ test('published all-in-one image is smoke-tested on every built architecture', (
   assert.match(testJob, /uses: docker\/setup-qemu-action@v3/);
   assert.match(testJob, /docker pull[\s\S]*?--platform "linux\/\$\{\{ matrix\.architecture \}\}"/);
   assert.match(testJob, /docker run[\s\S]*?--platform "linux\/\$\{\{ matrix\.architecture \}\}"/);
+  assert.match(testJob, /docker exec keeplocal-test curl -f http:\/\/127\.0\.0\.1:5001\/health/);
+});
+
+test('Whisper images cache model files without loading CTranslate2 during the build', () => {
+  for (const filename of ['Dockerfile.allinone', 'ai/Dockerfile']) {
+    const dockerfile = fs.readFileSync(path.join(root, filename), 'utf8');
+    const preload = dockerfile.match(/RUN[^\n]*(?:\\\n[^\n]*)*download_model[^\n]*/)?.[0] || '';
+
+    assert.match(preload, /from faster_whisper import download_model/, `${filename} must use download_model`);
+    assert.doesNotMatch(preload, /WhisperModel/, `${filename} must not construct a model while cross-building`);
+  }
 });


### PR DESCRIPTION
## What changed

- use faster-whisper's public `download_model` API to populate the model cache without constructing CTranslate2 during cross-platform builds
- apply the same download-only preload to split and all-in-one AI images
- wait for the AI `/health` endpoint inside both AMD64 and ARM64 smoke-test containers
- add deployment contract coverage for the preload and runtime AI check

## Why

PR #91 fixed the empty `WHISPER_MODEL` value and the replacement run passed that former failure point. Its fresh ARM64 QEMU build then remained inside Buildx for more than 35 minutes with no error or annotation. `WhisperModel(...)` downloads the model and immediately initializes CTranslate2; its supported `download_model(...)` helper caches the identical files without doing architecture runtime work during the build.

The new per-platform AI health check preserves—and strengthens—validation by proving the actual model loads in each running image.

## Verification

- backend: 40/40 tests
- AI: 4/4 tests
- all three Compose variants render successfully
- workflow YAML parses successfully
- `git diff --check` clean