### PR TITLE
Fix Vercel client deployment and Docker publish races

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,9 +17,14 @@ env:
   REGISTRY: docker.io
   IMAGE_NAME: keeplocal
 
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write

--- a/README.md
+++ b/README.md
@@ -161,6 +161,23 @@ docker compose restart
 docker compose down -v
 ```
 
+## Vercel Frontend Preview (Optional)
+
+Vercel can build the React client as a static preview. Set the project **Root
+Directory** to `client`; the checked-in `client/vercel.json` fixes the Vite
+build command, output directory, and OAuth callback rewrite.
+
+Use `VITE_API_URL` for the HTTPS origin of a separately deployed KeepLocal
+server. Existing projects that still define `REACT_APP_API_URL` remain
+compatible during migration, but `VITE_API_URL` takes precedence.
+
+Vercel hosts only the browser client—not MongoDB, private uploads, or the
+Whisper service. A functional deployment therefore also needs a reachable
+backend, matching `ALLOWED_ORIGINS` and `CLIENT_URL`, and same-origin proxying
+for cookie-based authentication. Keep Vercel as a protected visual preview if
+that backend path is not configured; use the Docker deployment above for the
+complete self-hosted application.
+
 ## Unraid Installation
 
 ### Method 1: Using Docker Compose (Recommended)

--- a/client/src/constants/api.js
+++ b/client/src/constants/api.js
@@ -1,6 +1,8 @@
 // API endpoints below already include /api. Accept both an origin and an
 // accidentally /api-suffixed base URL without ever producing /api/api.
-const configuredApiUrl = import.meta.env.VITE_API_URL || (import.meta.env.PROD ? '' : 'http://localhost:5000');
+const configuredApiUrl = import.meta.env.VITE_API_URL
+  || import.meta.env.REACT_APP_API_URL
+  || (import.meta.env.PROD ? '' : 'http://localhost:5000');
 export const API_BASE_URL = configuredApiUrl
   .trim()
   .replace(/\/+$/, '')

--- a/client/tests/vercelDeployment.test.js
+++ b/client/tests/vercelDeployment.test.js
@@ -1,0 +1,36 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const { pathToFileURL } = require('node:url');
+
+const root = path.resolve(__dirname, '..');
+
+test('Vercel has an explicit Vite build contract and OAuth callback rewrite', () => {
+  const config = JSON.parse(fs.readFileSync(path.join(root, 'vercel.json'), 'utf8'));
+
+  assert.equal(config.framework, 'vite');
+  assert.equal(config.buildCommand, 'npm run build');
+  assert.equal(config.outputDirectory, 'build');
+  assert.deepEqual(config.rewrites, [
+    { source: '/oauth/callback', destination: '/index.html' },
+  ]);
+});
+
+test('Vite exposes the legacy API URL without exposing arbitrary environment variables', async () => {
+  const configUrl = pathToFileURL(path.join(root, 'vite.config.mjs')).href;
+  const { default: config } = await import(configUrl);
+
+  assert.deepEqual(config.envPrefix, ['VITE_', 'REACT_APP_']);
+  assert.ok(!config.envPrefix.includes(''));
+});
+
+test('the client prefers VITE_API_URL and falls back to REACT_APP_API_URL', () => {
+  const source = fs.readFileSync(path.join(root, 'src/constants/api.js'), 'utf8');
+  const viteIndex = source.indexOf('import.meta.env.VITE_API_URL');
+  const legacyIndex = source.indexOf('import.meta.env.REACT_APP_API_URL');
+
+  assert.notEqual(viteIndex, -1);
+  assert.notEqual(legacyIndex, -1);
+  assert.ok(viteIndex < legacyIndex, 'VITE_API_URL must take precedence');
+});

--- a/client/tests/vercelDeployment.test.js
+++ b/client/tests/vercelDeployment.test.js
@@ -21,7 +21,7 @@ test('Vite exposes the legacy API URL without exposing arbitrary environment var
   const configUrl = pathToFileURL(path.join(root, 'vite.config.mjs')).href;
   const { default: config } = await import(configUrl);
 
-  assert.deepEqual(config.envPrefix, ['VITE_', 'REACT_APP_']);
+  assert.deepEqual(config.envPrefix, ['VITE_', 'REACT_APP_API_URL']);
   assert.ok(!config.envPrefix.includes(''));
 });
 

--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "buildCommand": "npm run build",
+  "outputDirectory": "build",
+  "rewrites": [
+    {
+      "source": "/oauth/callback",
+      "destination": "/index.html"
+    }
+  ]
+}

--- a/client/vite.config.mjs
+++ b/client/vite.config.mjs
@@ -3,6 +3,9 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  // Keep existing deployments working while they migrate from Create React
+  // App's REACT_APP_* convention to Vite's VITE_* convention.
+  envPrefix: ['VITE_', 'REACT_APP_'],
   build: {
     outDir: 'build',
     emptyOutDir: true

--- a/client/vite.config.mjs
+++ b/client/vite.config.mjs
@@ -3,9 +3,9 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
-  // Keep existing deployments working while they migrate from Create React
-  // App's REACT_APP_* convention to Vite's VITE_* convention.
-  envPrefix: ['VITE_', 'REACT_APP_'],
+  // Keep the legacy API variable available without exposing every
+  // REACT_APP_* value to browser code.
+  envPrefix: ['VITE_', 'REACT_APP_API_URL'],
   build: {
     outDir: 'build',
     emptyOutDir: true

--- a/server/tests/deploymentSecurity.test.js
+++ b/server/tests/deploymentSecurity.test.js
@@ -108,8 +108,11 @@ test('all-in-one image declares the Whisper model argument in its consuming stag
 
 test('published all-in-one image is smoke-tested on every built architecture', () => {
   const workflow = fs.readFileSync(path.join(root, '.github/workflows/docker-build.yml'), 'utf8');
+  const buildJob = workflow.match(/\n  build-and-push:\n([\s\S]*?)\n  test-image:\n/)?.[1] || '';
   const testJob = workflow.match(/\n  test-image:\n([\s\S]*)/)?.[1] || '';
 
+  assert.match(workflow, /concurrency:\n\s+group: docker-publish-\$\{\{ github\.ref \}\}\n\s+cancel-in-progress: true/);
+  assert.match(buildJob, /timeout-minutes: 45/);
   assert.match(testJob, /architecture:\n\s+- amd64\n\s+- arm64/);
   assert.match(testJob, /uses: docker\/setup-qemu-action@v3/);
   assert.match(testJob, /docker pull[\s\S]*?--platform "linux\/\$\{\{ matrix\.architecture \}\}"/);


### PR DESCRIPTION
## Summary

- add an explicit Vercel/Vite build contract for the `client` project
- route the existing `/oauth/callback` SPA deep link to `index.html` without masking `/api` failures
- preserve the legacy `REACT_APP_API_URL` deployment variable while preferring `VITE_API_URL`
- cancel superseded Docker publishes for the same ref and cap multi-arch builds at 45 minutes
- document that Vercel is frontend-only unless a compatible backend proxy is configured

## Verification

- server: 40/40 tests
- client: 25/25 tests
- client ESLint: passed
- Vite production build: passed
- controlled legacy-only API URL build: value embedded
- controlled dual-variable build: `VITE_API_URL` wins
- GitHub Actions workflow YAML: parsed successfully

## External configuration still required

The current Vercel deployment itself reports success, but its generated URL is protected by Vercel Authentication and redirects to SSO. Making it public requires a Vercel Project Settings change. A functional full KeepLocal deployment also needs same-origin `/api` and `/uploads` proxying to a reachable backend; the current self-hosted backend is protected by Authelia and is intentionally not exposed by this PR.

The already-running stale Docker run 29536851760 predates the new concurrency rule and should be cancelled manually so it cannot publish an older `latest` tag.