### PR TITLE
Make Docker metadata generation resilient

### DIFF
--- a/.github/scripts/docker-metadata.sh
+++ b/.github/scripts/docker-metadata.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+required_variables=(
+  DOCKERHUB_USERNAME
+  IMAGE_NAME
+  GITHUB_EVENT_NAME
+  GITHUB_OUTPUT
+  GITHUB_REF_NAME
+  GITHUB_REF_TYPE
+  GITHUB_REPOSITORY
+  GITHUB_SERVER_URL
+  GITHUB_SHA
+)
+
+for variable in "${required_variables[@]}"; do
+  if [[ -z "${!variable:-}" ]]; then
+    echo "Missing required environment variable: ${variable}" >&2
+    exit 1
+  fi
+done
+
+if [[ ! "${DOCKERHUB_USERNAME}" =~ ^[a-z0-9]+([._-][a-z0-9]+)*$ ]]; then
+  echo 'DOCKERHUB_USERNAME is not a valid Docker Hub namespace' >&2
+  exit 1
+fi
+
+if [[ ! "${IMAGE_NAME}" =~ ^[a-z0-9]+([._-][a-z0-9]+)*$ ]]; then
+  echo 'IMAGE_NAME is not a valid Docker image name' >&2
+  exit 1
+fi
+
+if [[ ! "${GITHUB_SHA}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+  echo 'GITHUB_SHA must be a 40-character hexadecimal commit SHA' >&2
+  exit 1
+fi
+
+image="${DOCKERHUB_USERNAME}/${IMAGE_NAME}"
+short_sha="${GITHUB_SHA:0:7}"
+created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+immutable_tag="${created%%T*}-${short_sha}"
+version="${immutable_tag}"
+tags=()
+
+add_tag() {
+  local candidate="$1"
+  local existing
+
+  for existing in "${tags[@]:-}"; do
+    if [[ "${existing}" == "${candidate}" ]]; then
+      return
+    fi
+  done
+
+  tags+=("${candidate}")
+}
+
+add_semver_tags() {
+  local requested_version="${1#v}"
+  local canonical_version
+  local identifier
+  local major
+  local minor
+  local prerelease
+  local -a prerelease_identifiers
+
+  if [[ ! "${requested_version}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$ ]]; then
+    echo "Invalid semantic version: $1" >&2
+    exit 1
+  fi
+
+  major="${BASH_REMATCH[1]}"
+  minor="${BASH_REMATCH[2]}"
+  canonical_version="${requested_version%%+*}"
+
+  if [[ "${canonical_version}" == *-* ]]; then
+    prerelease="${canonical_version#*-}"
+    IFS='.' read -r -a prerelease_identifiers <<< "${prerelease}"
+    for identifier in "${prerelease_identifiers[@]}"; do
+      if [[ "${identifier}" =~ ^0[0-9]+$ ]]; then
+        echo "Invalid semantic version: $1" >&2
+        exit 1
+      fi
+    done
+  fi
+
+  version="${canonical_version}"
+  add_tag "${image}:${canonical_version}"
+
+  # Pre-release versions must not replace the stable major/minor channels.
+  if [[ "${canonical_version}" != *-* ]]; then
+    add_tag "${image}:${major}.${minor}"
+    add_tag "${image}:${major}"
+    add_tag "${image}:latest"
+  fi
+}
+
+add_tag "${image}:${immutable_tag}"
+
+if [[ "${GITHUB_EVENT_NAME}" == 'workflow_dispatch' && "${INPUT_VERSION:-latest}" != 'latest' ]]; then
+  if [[ "${GITHUB_REF_TYPE}" != 'branch' || "${GITHUB_REF_NAME}" != 'main' ]]; then
+    echo 'Versioned manual releases must be dispatched from the main branch' >&2
+    exit 1
+  fi
+
+  add_semver_tags "${INPUT_VERSION}"
+elif [[ "${GITHUB_REF_TYPE}" == 'tag' ]]; then
+  add_semver_tags "${GITHUB_REF_NAME}"
+elif [[ "${GITHUB_REF_TYPE}" == 'branch' ]]; then
+  if [[ "${GITHUB_REF_NAME}" != 'main' ]]; then
+    echo "Refusing to publish an unconfigured branch: ${GITHUB_REF_NAME}" >&2
+    exit 1
+  fi
+
+  version='main'
+  add_tag "${image}:main"
+  add_tag "${image}:latest"
+else
+  echo "Unsupported Git ref type: ${GITHUB_REF_TYPE}" >&2
+  exit 1
+fi
+
+source_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+
+{
+  echo 'tags<<__DOCKER_TAGS__'
+  printf '%s\n' "${tags[@]}"
+  echo '__DOCKER_TAGS__'
+  echo 'labels<<__DOCKER_LABELS__'
+  echo "org.opencontainers.image.created=${created}"
+  echo 'org.opencontainers.image.description=Vibecoded Google Keep Clone'
+  echo 'org.opencontainers.image.licenses='
+  echo "org.opencontainers.image.revision=${GITHUB_SHA}"
+  echo "org.opencontainers.image.source=${source_url}"
+  echo 'org.opencontainers.image.title=KeepLocal'
+  echo "org.opencontainers.image.url=${source_url}"
+  echo "org.opencontainers.image.version=${version}"
+  echo '__DOCKER_LABELS__'
+  echo "test-tag=${immutable_tag}"
+  echo "version=${version}"
+} >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -25,6 +25,8 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    outputs:
+      test-tag: ${{ steps.meta.outputs.test-tag }}
     permissions:
       contents: read
       packages: write
@@ -47,17 +49,10 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,prefix={{date 'YYYY-MM-DD'}}-
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: .github/scripts/docker-metadata.sh
 
       - name: Build and push All-in-One Docker image
         uses: docker/build-push-action@v5
@@ -106,7 +101,7 @@ jobs:
         run: |
           docker pull \
             --platform "linux/${{ matrix.architecture }}" \
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ needs.build-and-push.outputs.test-tag }}
 
           docker run -d \
             --name keeplocal-test \
@@ -115,7 +110,7 @@ jobs:
             -e JWT_SECRET="${{ steps.jwt.outputs.secret }}" \
             -e ALLOWED_ORIGINS="http://localhost:3000" \
             -e NODE_ENV="production" \
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ needs.build-and-push.outputs.test-tag }}
 
       - name: Wait for services to start
         run: |

--- a/server/tests/deploymentSecurity.test.js
+++ b/server/tests/deploymentSecurity.test.js
@@ -1,9 +1,42 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const childProcess = require('node:child_process');
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 
 const root = path.resolve(__dirname, '../..');
+
+const runDockerMetadata = (overrides = {}) => {
+  const outputDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'keeplocal-docker-metadata-'));
+  const outputPath = path.join(outputDirectory, 'github-output');
+  const sha = '0123456789abcdef0123456789abcdef01234567';
+
+  const result = childProcess.spawnSync(
+    'bash',
+    [path.join(root, '.github/scripts/docker-metadata.sh')],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        DOCKERHUB_USERNAME: 'example',
+        IMAGE_NAME: 'keeplocal',
+        GITHUB_EVENT_NAME: 'push',
+        GITHUB_OUTPUT: outputPath,
+        GITHUB_REF_NAME: 'main',
+        GITHUB_REF_TYPE: 'branch',
+        GITHUB_REPOSITORY: 'example/KeepLocal',
+        GITHUB_SERVER_URL: 'https://github.com',
+        GITHUB_SHA: sha,
+        ...overrides,
+      },
+    },
+  );
+
+  const output = fs.existsSync(outputPath) ? fs.readFileSync(outputPath, 'utf8') : '';
+  fs.rmSync(outputDirectory, { recursive: true, force: true });
+  return { ...result, output, sha };
+};
 
 test('all-in-one nginx sends private uploads through backend authorization', () => {
   const config = fs.readFileSync(path.join(root, 'nginx-allinone.conf'), 'utf8');
@@ -113,11 +146,86 @@ test('published all-in-one image is smoke-tested on every built architecture', (
 
   assert.match(workflow, /concurrency:\n\s+group: docker-publish-\$\{\{ github\.ref \}\}\n\s+cancel-in-progress: true/);
   assert.match(buildJob, /timeout-minutes: 45/);
+  assert.match(buildJob, /run: \.github\/scripts\/docker-metadata\.sh/);
+  assert.doesNotMatch(buildJob, /docker\/metadata-action/);
+  assert.match(buildJob, /outputs:\n\s+test-tag: \$\{\{ steps\.meta\.outputs\.test-tag \}\}/);
   assert.match(testJob, /architecture:\n\s+- amd64\n\s+- arm64/);
   assert.match(testJob, /uses: docker\/setup-qemu-action@v3/);
   assert.match(testJob, /docker pull[\s\S]*?--platform "linux\/\$\{\{ matrix\.architecture \}\}"/);
   assert.match(testJob, /docker run[\s\S]*?--platform "linux\/\$\{\{ matrix\.architecture \}\}"/);
+  assert.match(testJob, /needs\.build-and-push\.outputs\.test-tag/);
   assert.match(testJob, /docker exec keeplocal-test curl -f http:\/\/127\.0\.0\.1:5001\/health/);
+});
+
+test('Docker metadata is generated locally for main and semantic-version releases', () => {
+  const main = runDockerMetadata();
+  assert.equal(main.status, 0, main.stderr);
+  assert.match(main.output, /example\/keeplocal:\d{4}-\d{2}-\d{2}-0123456/);
+  assert.match(main.output, /example\/keeplocal:main/);
+  assert.match(main.output, /example\/keeplocal:latest/);
+  assert.match(main.output, new RegExp(`org\\.opencontainers\\.image\\.revision=${main.sha}`));
+  assert.match(main.output, /test-tag=\d{4}-\d{2}-\d{2}-0123456/);
+
+  const release = runDockerMetadata({
+    GITHUB_REF_NAME: 'v2.3.4',
+    GITHUB_REF_TYPE: 'tag',
+  });
+  assert.equal(release.status, 0, release.stderr);
+  assert.match(release.output, /example\/keeplocal:2\.3\.4/);
+  assert.match(release.output, /example\/keeplocal:2\.3\n/);
+  assert.match(release.output, /example\/keeplocal:2\n/);
+  assert.match(release.output, /example\/keeplocal:latest/);
+
+  const prerelease = runDockerMetadata({
+    GITHUB_REF_NAME: 'v2.3.4-rc.1',
+    GITHUB_REF_TYPE: 'tag',
+  });
+  assert.equal(prerelease.status, 0, prerelease.stderr);
+  assert.match(prerelease.output, /example\/keeplocal:2\.3\.4-rc\.1/);
+  assert.doesNotMatch(prerelease.output, /example\/keeplocal:2\.3\n/);
+  assert.doesNotMatch(prerelease.output, /example\/keeplocal:2\n/);
+  assert.doesNotMatch(prerelease.output, /example\/keeplocal:latest/);
+
+  const buildMetadata = runDockerMetadata({
+    GITHUB_REF_NAME: 'v2.3.4+build.5',
+    GITHUB_REF_TYPE: 'tag',
+  });
+  assert.equal(buildMetadata.status, 0, buildMetadata.stderr);
+  assert.match(buildMetadata.output, /example\/keeplocal:2\.3\.4/);
+  assert.match(buildMetadata.output, /org\.opencontainers\.image\.version=2\.3\.4/);
+  assert.doesNotMatch(buildMetadata.output, /example\/keeplocal:2\.3\.4-build\.5/);
+  assert.doesNotMatch(buildMetadata.output, /example\/keeplocal:2\.3\.4\+build\.5/);
+});
+
+test('Docker metadata rejects invalid manually supplied release tags', () => {
+  const invalid = runDockerMetadata({
+    GITHUB_EVENT_NAME: 'workflow_dispatch',
+    INPUT_VERSION: 'latest;echo-pwned',
+  });
+
+  assert.notEqual(invalid.status, 0);
+  assert.match(invalid.stderr, /Invalid semantic version/);
+  assert.equal(invalid.output, '');
+
+  for (const version of ['v01.2.3', 'v1.2.3-01']) {
+    const leadingZero = runDockerMetadata({
+      GITHUB_REF_NAME: version,
+      GITHUB_REF_TYPE: 'tag',
+    });
+    assert.notEqual(leadingZero.status, 0);
+    assert.match(leadingZero.stderr, /Invalid semantic version/);
+    assert.equal(leadingZero.output, '');
+  }
+
+  const nonMainRelease = runDockerMetadata({
+    GITHUB_EVENT_NAME: 'workflow_dispatch',
+    GITHUB_REF_NAME: 'feature/unreviewed-release',
+    INPUT_VERSION: 'v9.9.9',
+  });
+
+  assert.notEqual(nonMainRelease.status, 0);
+  assert.match(nonMainRelease.stderr, /must be dispatched from the main branch/);
+  assert.equal(nonMainRelease.output, '');
 });
 
 test('Whisper images cache model files without loading CTranslate2 during the build', () => {


### PR DESCRIPTION
## Summary

- replace `docker/metadata-action` with deterministic local tag and OCI-label generation
- preserve the existing main, latest, immutable date/SHA, SemVer, prerelease, and label contract
- smoke-test the exact image tag produced by the build on AMD64 and ARM64
- reject malformed or non-main manual release requests

## Root cause

The merged workflow reached `docker/metadata-action@v5`, which performs a GitHub REST repository lookup. During GitHub's degraded REST API incident that lookup returned the `Unicorn!` HTML error page instead of JSON on two consecutive attempts, so the Docker build never started.

## Verification

- server: 42/42 tests
- client: 25/25 tests
- client ESLint: passed
- Vite production build: passed
- Bash syntax and workflow YAML parsing: passed
- remote Git tree matches the locally verified tree `37cdfb4e17a6a94192687cdf918c2c5f5e846cf1`

## Operational note

The older [workflow run #81](https://github.com/zwaetschge/KeepLocal/actions/runs/29536851760) is still stuck and predates the new concurrency guard; it should be cancelled before merging this PR. Vercel's missing deployment for [PR #93](https://github.com/zwaetschge/KeepLocal/pull/93) coincided with active GitHub REST and Vercel GitHub-login incidents, so this PR also provides a fresh post-fix integration event.