### PR TITLE
Add an isolated public demo for the Vercel app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ yarn.lock
 
 # Environment variables
 .env
+.env.demo
 .env.local
 .env.*.local
 

--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -144,14 +144,14 @@ ENV NODE_ENV=production \
     TRUST_PROXY=1 \
     AI_SERVICE_URL=http://localhost:5001 \
     JWT_EXPIRES_IN=7d \
-    CSRF_SECRET="" \
+    DEMO_MODE=false \
+    DEMO_RESET_INTERVAL_HOURS=6 \
+    DEMO_NOTE_LIMIT=100 \
     COOKIE_SECURE="" \
     CLIENT_URL="" \
     GOOGLE_CLIENT_ID="" \
-    GOOGLE_CLIENT_SECRET="" \
     GOOGLE_CALLBACK_URL="" \
     GITHUB_CLIENT_ID="" \
-    GITHUB_CLIENT_SECRET="" \
     GITHUB_CALLBACK_URL=""
 
 # Health check

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 A self-hosted notes application inspired by Google Keep. Create, edit, organize, and collaborate on your notes with an intuitive, feature-rich user interface.
 
+## Public Demo
+
+[Open the public KeepLocal demo](https://keep-local-silk.vercel.app/) and choose
+**Try demo** / **Demo ausprobieren**. No account or shared password is required.
+
+The demo runs in an isolated database and upload directory; it is not connected
+to the maintainer's private KeepLocal installation. Its sample notes are reset
+every six hours. Treat it as a public sandbox: do not enter personal or
+confidential information. Uploads, transcription, link previews, API keys,
+friends, and note sharing are disabled in demo mode.
+
 ## Screenshots
 
 Each persistent theme is shown with the same representative notes on desktop and mobile.
@@ -161,22 +172,73 @@ docker compose restart
 docker compose down -v
 ```
 
-## Vercel Frontend Preview (Optional)
+## Vercel Public Demo
 
-Vercel can build the React client as a static preview. Set the project **Root
-Directory** to `client`; the checked-in `client/vercel.json` fixes the Vite
-build command, output directory, and OAuth callback rewrite.
+Vercel builds only the React client. Set the project **Root Directory** to
+`client`; the checked-in `client/vercel.json` proxies `/api` and `/uploads` to
+the isolated demo backend so session and CSRF cookies remain same-origin from
+the browser's perspective. Leave
+`VITE_API_URL` and the legacy `REACT_APP_API_URL` unset for this deployment.
+The external rewrite target is intentionally fixed to
+`keeplocal-demo.zwaetschge-webui.ch`; changing the demo hostname requires a
+matching change to `client/vercel.json`, `ALLOWED_ORIGINS`, and `CLIENT_URL`.
 
-Use `VITE_API_URL` for the HTTPS origin of a separately deployed KeepLocal
-server. Existing projects that still define `REACT_APP_API_URL` remain
-compatible during migration, but `VITE_API_URL` takes precedence.
+### Deploy the isolated demo backend
 
-Vercel hosts only the browser client—not MongoDB, private uploads, or the
-Whisper service. A functional deployment therefore also needs a reachable
-backend, matching `ALLOWED_ORIGINS` and `CLIENT_URL`, and same-origin proxying
-for cookie-based authentication. Keep Vercel as a protected visual preview if
-that backend path is not configured; use the Docker deployment above for the
-complete self-hosted application.
+`docker-compose.demo.yml` is the production contract for the public sandbox.
+It has no host port, joins only the existing `brian_traefik-public` network,
+and gives Traefik routes only for `/api` and `/uploads`. Its MongoDB and upload
+bind mounts use `/mnt/user/appdata/keeplocal-demo`, never the normal KeepLocal
+paths.
+
+Prepare the host and a mode-`0600` environment file outside the repository.
+Use the published multi-architecture manifest digest, not `latest` or another
+mutable tag:
+
+```bash
+DEMO_DIR=/mnt/user/appdata/keeplocal-demo
+DEMO_ENV="$DEMO_DIR/demo.env"
+install -d -m 0700 "$DEMO_DIR" "$DEMO_DIR/mongodb" "$DEMO_DIR/uploads"
+
+export KEEPLOCAL_DEMO_IMAGE='valentin2177/keeplocal@sha256:<manifest-digest>'
+export JWT_SECRET="$(openssl rand -hex 48)"
+export CSRF_SECRET="$(openssl rand -hex 48)"
+umask 077
+printf '%s\n' \
+  "KEEPLOCAL_DEMO_IMAGE=$KEEPLOCAL_DEMO_IMAGE" \
+  "JWT_SECRET=$JWT_SECRET" \
+  "CSRF_SECRET=$CSRF_SECRET" \
+  'TRAEFIK_ENABLE=false' \
+  > "$DEMO_ENV"
+
+docker compose --env-file "$DEMO_ENV" -f docker-compose.demo.yml config >/dev/null
+docker compose --env-file "$DEMO_ENV" -f docker-compose.demo.yml up -d
+```
+
+The first start keeps Traefik disabled. Verify the private health endpoint and
+demo seeding before making it reachable:
+
+```bash
+docker inspect --format '{{.State.Health.Status}}' keeplocal-demo
+docker exec keeplocal-demo curl -fsS http://127.0.0.1/api/health
+docker exec keeplocal-demo curl -fsS http://127.0.0.1/api/auth/providers
+```
+
+Then enable the route and verify both the backend and the same-origin Vercel
+proxy:
+
+```bash
+sed -i 's/^TRAEFIK_ENABLE=false$/TRAEFIK_ENABLE=true/' "$DEMO_ENV"
+docker compose --env-file "$DEMO_ENV" -f docker-compose.demo.yml up -d --force-recreate
+curl -fsS https://keeplocal-demo.zwaetschge-webui.ch/api/health
+curl -fsS https://keep-local-silk.vercel.app/api/auth/providers
+```
+
+To take the demo off the internet without deleting its data, set
+`TRAEFIK_ENABLE=false` in `demo.env` and recreate the service. To roll back an
+application release, replace `KEEPLOCAL_DEMO_IMAGE` with the previous verified
+manifest digest and recreate it. Do not run `down -v` or delete the two bind
+mounts unless a full, irreversible sandbox reset is intended.
 
 ## Unraid Installation
 
@@ -527,6 +589,9 @@ KeepLocal implements multiple security layers:
 | `COOKIE_SECURE` | Optional `true`/`false` override for automatic HTTPS cookie detection | Auto |
 | `CLIENT_URL` | Explicit frontend origin for OAuth redirects | First allowed origin |
 | `WHISPER_MODEL` | AI model for split deployments (`tiny`, `base`, `small`, ...) | `base` |
+| `DEMO_MODE` | Enables the isolated public-demo account and restrictions | `false` |
+| `DEMO_RESET_INTERVAL_HOURS` | Hours between demo fixture resets (1–168) | `6` |
+| `DEMO_NOTE_LIMIT` | Maximum notes in the shared demo account (1–500) | `100` |
 
 ## Notes
 

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -157,6 +157,104 @@ body.eink-mode::before {
   gap: var(--space-4);
 }
 
+.demo-user-identity {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.demo-user-icon {
+  flex-shrink: 0;
+  color: var(--text-secondary);
+}
+
+.demo-user-badge,
+.mobile-demo-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 2px var(--space-2);
+  background: #F4A340;
+  border: 1px solid #263D5B;
+  border-radius: 5px;
+  color: #172033;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-bold);
+  letter-spacing: 0.04em;
+  line-height: 1;
+  text-transform: uppercase;
+  transform: rotate(1deg);
+}
+
+/* The public demo notice stays visible above the shared workspace. */
+.demo-banner {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  padding: var(--space-3) var(--space-6);
+  background: #FFF7ED;
+  border-bottom: 2px solid #D97706;
+  color: #334155;
+  font-size: var(--font-size-sm);
+  line-height: var(--leading-relaxed);
+  z-index: calc(var(--z-header) - 1);
+}
+
+.demo-banner strong {
+  color: #7C3500;
+  font-weight: var(--font-bold);
+}
+
+.demo-banner span + span::before {
+  content: '•';
+  margin-right: var(--space-3);
+  color: #D97706;
+  font-weight: var(--font-bold);
+}
+
+.dark-mode .demo-user-badge,
+.oled-mode .demo-user-badge,
+.dark-mode .mobile-demo-badge,
+.oled-mode .mobile-demo-badge {
+  background: #F4B860;
+  border-color: #F8FAFC;
+  color: #172033;
+}
+
+.dark-mode .demo-banner,
+.oled-mode .demo-banner {
+  background: #251D16;
+  border-bottom-color: #F4B860;
+  color: #E2E8F0;
+}
+
+.dark-mode .demo-banner strong,
+.oled-mode .demo-banner strong {
+  color: #F4B860;
+}
+
+.eink-mode .demo-user-badge,
+.eink-mode .mobile-demo-badge {
+  background: #ffffff;
+  border: 2px solid #000000;
+  color: #000000;
+  transform: none;
+}
+
+.eink-mode .demo-banner {
+  background: #ffffff;
+  border-bottom: 2px solid #000000;
+  color: #000000;
+}
+
+.eink-mode .demo-banner strong,
+.eink-mode .demo-banner span + span::before {
+  color: #000000;
+}
+
 .user-info .theme-toggle {
   position: static;
   width: 40px;
@@ -748,6 +846,23 @@ body.eink-mode::before {
 
   .user-info {
     gap: var(--space-2);
+  }
+
+  .demo-banner {
+    align-items: flex-start;
+    justify-content: flex-start;
+    gap: var(--space-1) var(--space-2);
+    padding: var(--space-2) var(--space-4);
+    font-size: var(--font-size-xs);
+  }
+
+  .demo-banner strong,
+  .demo-banner span {
+    width: 100%;
+  }
+
+  .demo-banner span + span::before {
+    margin-right: var(--space-2);
   }
 
   .pagination {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -24,7 +24,7 @@ import { initializeCSRF, notesAPI } from './services/api';
 import { useKeyboardShortcuts } from './hooks';
 
 function AppContent() {
-  const { user, isLoggedIn, loading: authLoading, setupNeeded, login, register, logout, setup, completeOAuthLogin } = useAuth();
+  const { user, isLoggedIn, loading: authLoading, setupNeeded, login, demoLogin, register, logout, setup, completeOAuthLogin } = useAuth();
   const { t } = useLanguage();
   const [notes, setNotes] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -345,6 +345,11 @@ function AppContent() {
     showToast('Erfolgreich angemeldet', 'success');
   };
 
+  const handleDemoLogin = async () => {
+    await demoLogin();
+    showToast(t('loginSuccess'), 'success');
+  };
+
   const handleRegister = async (username, email, password) => {
     await register(username, email, password);
     showToast('Erfolgreich registriert', 'success');
@@ -416,6 +421,7 @@ function AppContent() {
         ) : (
           <Login
             onLogin={handleLogin}
+            onDemoLogin={handleDemoLogin}
             onSwitchToRegister={() => setShowRegister(true)}
           />
         )}
@@ -451,15 +457,26 @@ function AppContent() {
             aria-label={t('searchNotes')}
           />
           <div className="user-info">
-              <ThemeToggle theme={theme} onToggle={toggleTheme} />
-            <button
-              className="user-name clickable"
-              onClick={() => setShowSettings(true)}
-              title={`${user?.email}${user?.isAdmin ? ` (${t('admin')})` : ''}`}
-              aria-label={t('settings') || 'Einstellungen'}
-            >
-              👤 {user?.username}
-            </button>
+            <ThemeToggle theme={theme} onToggle={toggleTheme} />
+            {user?.isDemo ? (
+              <div className="demo-user-identity" title={t('demoBannerTitle')}>
+                <svg className="demo-user-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                  <circle cx="12" cy="8" r="4"/>
+                  <path d="M4 21a8 8 0 0116 0"/>
+                </svg>
+                <span className="user-name">{user?.username}</span>
+                <span className="demo-user-badge">{t('demoBadge')}</span>
+              </div>
+            ) : (
+              <button
+                className="user-name clickable"
+                onClick={() => setShowSettings(true)}
+                title={`${user?.email}${user?.isAdmin ? ` (${t('admin')})` : ''}`}
+                aria-label={t('settings') || 'Einstellungen'}
+              >
+                👤 {user?.username}
+              </button>
+            )}
             <button
               onClick={handleLogout}
               className="btn-logout"
@@ -472,6 +489,15 @@ function AppContent() {
         </div>
       </header>
 
+      {user?.isDemo && (
+        <section className="demo-banner" aria-label={t('demoBannerTitle')}>
+          <strong>{t('demoBannerTitle')}</strong>
+          <span>{t('demoBannerPrivacy')}</span>
+          <span>{t('demoBannerRestrictions')}</span>
+          <span>{t('demoBannerReset')}</span>
+        </section>
+      )}
+
       <div className="App-container">
         <Sidebar
           allTags={allTags}
@@ -480,7 +506,7 @@ function AppContent() {
           noteCount={noteCounts.active}
           isAdmin={user?.isAdmin}
           onAdminClick={() => setShowAdminConsole(true)}
-          onSettingsClick={() => setShowSettings(true)}
+          onSettingsClick={user?.isDemo ? undefined : () => setShowSettings(true)}
           user={user}
           onLogout={handleLogout}
           theme={theme}
@@ -490,7 +516,7 @@ function AppContent() {
           archivedCount={noteCounts.archived}
           showArchived={showArchived}
           onShowArchivedToggle={() => setShowArchived(!showArchived)}
-          onOpenFriends={() => setShowFriendsModal(true)}
+          onOpenFriends={user?.isDemo ? undefined : () => setShowFriendsModal(true)}
         />
 
         <main className="App-main" role="main">
@@ -516,7 +542,7 @@ function AppContent() {
                   onUpdateNote={updateNote}
                   onTogglePin={togglePinNote}
                   onToggleArchive={toggleArchiveNote}
-                  onOpenCollaborate={openCollaborateModal}
+                  onOpenCollaborate={user?.isDemo ? undefined : openCollaborateModal}
                   onOpenModal={openNoteModal}
                   onDragStart={handleDragStart}
                   onDragEnd={handleDragEnd}
@@ -535,7 +561,7 @@ function AppContent() {
                   onUpdateNote={updateNote}
                   onTogglePin={togglePinNote}
                   onToggleArchive={toggleArchiveNote}
-                  onOpenCollaborate={openCollaborateModal}
+                  onOpenCollaborate={user?.isDemo ? undefined : openCollaborateModal}
                   onOpenModal={openNoteModal}
                   onDragStart={handleDragStart}
                   onDragEnd={handleDragEnd}
@@ -609,7 +635,7 @@ function AppContent() {
         />
       )}
 
-      {showAdminConsole && user?.isAdmin && (
+      {showAdminConsole && user?.isAdmin && !user?.isDemo && (
         <AdminConsole onClose={() => setShowAdminConsole(false)} />
       )}
 
@@ -619,25 +645,29 @@ function AppContent() {
           onSave={handleModalSave}
           onClose={closeNoteModal}
           onToggleArchive={toggleArchiveNote}
-          onOpenCollaborate={openCollaborateModal}
+          onOpenCollaborate={user?.isDemo ? undefined : openCollaborateModal}
           onDelete={deleteNote}
         />
       )}
 
-      <FriendsModal
-        isOpen={showFriendsModal}
-        onClose={() => setShowFriendsModal(false)}
-        isAdmin={user?.isAdmin}
-      />
+      {!user?.isDemo && (
+        <>
+          <FriendsModal
+            isOpen={showFriendsModal}
+            onClose={() => setShowFriendsModal(false)}
+            isAdmin={user?.isAdmin}
+          />
 
-      <CollaborateModal
-        isOpen={showCollaborateModal}
-        onClose={() => setShowCollaborateModal(false)}
-        note={collaborateNote}
-        onNoteUpdate={handleNoteShared}
-      />
+          <CollaborateModal
+            isOpen={showCollaborateModal}
+            onClose={() => setShowCollaborateModal(false)}
+            note={collaborateNote}
+            onNoteUpdate={handleNoteShared}
+          />
+        </>
+      )}
 
-      {showSettings && (
+      {showSettings && !user?.isDemo && (
         <Settings
           onClose={() => setShowSettings(false)}
           isAdmin={user?.isAdmin}

--- a/client/src/components/Auth.css
+++ b/client/src/components/Auth.css
@@ -81,6 +81,108 @@ body:not(.dark-mode):not(.oled-mode):not(.eink-mode):not(.doodle-mode) .auth-con
   line-height: var(--leading-relaxed);
 }
 
+/* Public demo entry point */
+.demo-login-panel {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  margin: calc(-1 * var(--space-2)) 0 var(--space-8);
+  padding: var(--space-5);
+  overflow: hidden;
+  background: #FFF7ED;
+  border: 2px solid #D97706;
+  border-radius: 8px;
+  box-shadow: 4px 4px 0 rgba(217, 119, 6, 0.2);
+  transform: rotate(-0.15deg);
+}
+
+.demo-login-panel::after {
+  content: '';
+  position: absolute;
+  width: 56px;
+  height: 16px;
+  top: 12px;
+  right: -18px;
+  border-top: 3px solid #263D5B;
+  border-bottom: 2px solid #E9A23B;
+  transform: rotate(24deg);
+  pointer-events: none;
+}
+
+.demo-login-copy {
+  position: relative;
+  z-index: 1;
+}
+
+.demo-login-kicker {
+  display: inline-block;
+  margin-bottom: var(--space-2);
+  color: #8A3F00;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-bold);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.demo-login-copy h2 {
+  margin: 0 0 var(--space-2);
+  color: #172033;
+  font-family: var(--font-display);
+  font-size: var(--font-size-xl);
+  line-height: var(--leading-tight);
+}
+
+.demo-login-copy p {
+  margin: 0;
+  color: #334155;
+  font-size: var(--font-size-sm);
+  line-height: var(--leading-relaxed);
+}
+
+.demo-login-button {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  background: #F4A340;
+  border: 2px solid #263D5B;
+  border-radius: 6px;
+  color: #172033;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-bold);
+  transition: transform var(--duration-fast) var(--ease-default),
+              box-shadow var(--duration-fast) var(--ease-default),
+              background-color var(--duration-fast) var(--ease-default);
+}
+
+.demo-login-button:hover:not(:disabled) {
+  background: #FFB75D;
+  box-shadow: 3px 3px 0 #263D5B;
+  transform: translate(-1px, -1px);
+}
+
+.demo-login-button:active:not(:disabled) {
+  box-shadow: 1px 1px 0 #263D5B;
+  transform: translate(1px, 1px);
+}
+
+.demo-login-button:focus-visible {
+  outline: 3px solid #49B6E5;
+  outline-offset: 3px;
+}
+
+.demo-login-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
 .auth-form {
   display: flex;
   flex-direction: column;
@@ -333,6 +435,28 @@ body.dark-mode .auth-error {
   color: var(--error-color);
 }
 
+body.dark-mode .demo-login-panel,
+body.oled-mode .demo-login-panel {
+  background: #251D16;
+  border-color: #F4B860;
+  box-shadow: 4px 4px 0 rgba(244, 184, 96, 0.22);
+}
+
+body.dark-mode .demo-login-kicker,
+body.oled-mode .demo-login-kicker {
+  color: #F4B860;
+}
+
+body.dark-mode .demo-login-copy h2,
+body.oled-mode .demo-login-copy h2 {
+  color: #F8FAFC;
+}
+
+body.dark-mode .demo-login-copy p,
+body.oled-mode .demo-login-copy p {
+  color: #E2E8F0;
+}
+
 body.dark-mode .auth-button {
   background: #49B6E5;
   border-color: #49B6E5;
@@ -402,6 +526,36 @@ body.eink-mode .auth-error {
   background: #f0f0f0;
   border: 2px solid #000000;
   color: #000000;
+}
+
+body.eink-mode .demo-login-panel {
+  background: #ffffff;
+  border: 2px solid #000000;
+  box-shadow: none;
+  transform: none;
+}
+
+body.eink-mode .demo-login-panel::after {
+  border-color: #000000;
+}
+
+body.eink-mode .demo-login-kicker,
+body.eink-mode .demo-login-copy h2,
+body.eink-mode .demo-login-copy p {
+  color: #000000;
+}
+
+body.eink-mode .demo-login-button {
+  background: #ffffff;
+  border-color: #000000;
+  color: #000000;
+}
+
+body.eink-mode .demo-login-button:hover:not(:disabled) {
+  background: #000000;
+  box-shadow: none;
+  color: #ffffff;
+  transform: none;
 }
 
 body.eink-mode .form-group input:focus {

--- a/client/src/components/Login.jsx
+++ b/client/src/components/Login.jsx
@@ -4,14 +4,19 @@ import { API_BASE_URL } from '../constants/api';
 import { parseResponse } from '../services/api/apiUtils';
 import './Auth.css';
 
-function Login({ onLogin, onSwitchToRegister }) {
+function Login({ onLogin, onDemoLogin, onSwitchToRegister }) {
   const { t } = useLanguage();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
-  const [loading, setLoading] = useState(false);
+  const [loadingAction, setLoadingAction] = useState(null);
   const [registrationEnabled, setRegistrationEnabled] = useState(false);
-  const [oauthProviders, setOauthProviders] = useState({ google: false, github: false });
+  const [oauthProviders, setOauthProviders] = useState({
+    google: false,
+    github: false,
+    demo: false,
+  });
+  const loading = loadingAction !== null;
 
   useEffect(() => {
     const checkRegistrationStatus = async () => {
@@ -55,14 +60,27 @@ function Login({ onLogin, onSwitchToRegister }) {
       return;
     }
 
-    setLoading(true);
+    setLoadingAction('credentials');
 
     try {
       await onLogin(email, password);
     } catch (err) {
       setError(err.message || t('loginFailed'));
     } finally {
-      setLoading(false);
+      setLoadingAction(null);
+    }
+  };
+
+  const handleDemoLogin = async () => {
+    setError('');
+    setLoadingAction('demo');
+
+    try {
+      await onDemoLogin();
+    } catch (err) {
+      setError(err.message || t('demoLoginFailed'));
+    } finally {
+      setLoadingAction(null);
     }
   };
 
@@ -79,6 +97,26 @@ function Login({ onLogin, onSwitchToRegister }) {
           <h1>KeepLocal</h1>
           <p>{t('loginSubtitle')}</p>
         </div>
+
+        {oauthProviders.demo && onDemoLogin && (
+          <section className="demo-login-panel" aria-labelledby="demo-login-title">
+            <div className="demo-login-copy">
+              <span className="demo-login-kicker">{t('publicDemo')}</span>
+              <h2 id="demo-login-title">{t('demoIntroTitle')}</h2>
+              <p id="demo-login-description">{t('demoIntroBody')}</p>
+            </div>
+            <button
+              type="button"
+              className="demo-login-button"
+              onClick={handleDemoLogin}
+              disabled={loading}
+              aria-describedby="demo-login-description"
+            >
+              {loadingAction === 'demo' ? t('demoEntering') : t('demoTryNow')}
+              <span aria-hidden="true">→</span>
+            </button>
+          </section>
+        )}
 
         <form onSubmit={handleSubmit} className="auth-form">
           {error && (
@@ -123,7 +161,7 @@ function Login({ onLogin, onSwitchToRegister }) {
             className="auth-button"
             disabled={loading}
           >
-            {loading ? t('loggingIn') : t('login')}
+            {loadingAction === 'credentials' ? t('loggingIn') : t('login')}
           </button>
         </form>
 

--- a/client/src/components/Note.jsx
+++ b/client/src/components/Note.jsx
@@ -269,23 +269,25 @@ function Note({ note, index, onDelete, onUpdate, onTogglePin, onToggleArchive, o
               <path d="M21 8v13H3V8M1 3h22v5H1zM10 12h4"/>
             </svg>
           </button>
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onOpenCollaborate(note);
-            }}
-            className="action-btn collaborate-btn"
-            disabled={Boolean(operation)}
-            title={t('share')}
-            aria-label={t('share')}
-          >
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
-              <circle cx="9" cy="7" r="4"/>
-              <path d="M23 21v-2a4 4 0 0 0-3-3.87"/>
-              <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
-            </svg>
-          </button>
+          {onOpenCollaborate && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onOpenCollaborate(note);
+              }}
+              className="action-btn collaborate-btn"
+              disabled={Boolean(operation)}
+              title={t('share')}
+              aria-label={t('share')}
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
+                <circle cx="9" cy="7" r="4"/>
+                <path d="M23 21v-2a4 4 0 0 0-3-3.87"/>
+                <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
+              </svg>
+            </button>
+          )}
           <button
             onClick={(e) => {
               e.stopPropagation();

--- a/client/src/components/NoteModal.jsx
+++ b/client/src/components/NoteModal.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
+import { useAuth } from '../contexts/AuthContext';
 import { useSettings } from '../contexts/SettingsContext';
 import './NoteModal.css';
 import ColorPicker from './ColorPicker';
@@ -11,7 +12,9 @@ import notesAPI from '../services/api/notesAPI';
 
 function NoteModal({ note, onSave, onClose, onToggleArchive, onOpenCollaborate, onDelete }) {
   const { t } = useLanguage();
+  const { user } = useAuth();
   const { settings } = useSettings();
+  const isDemo = Boolean(user?.isDemo);
   const [title, setTitle] = useState(note?.title || '');
   const [content, setContent] = useState(note?.content || '');
   const [tags, setTags] = useState(note?.tags || []);
@@ -42,7 +45,7 @@ function NoteModal({ note, onSave, onClose, onToggleArchive, onOpenCollaborate, 
   }, []);
 
   // Custom hooks for link preview and todo list management
-  const { linkPreviews, setLinkPreviews } = useLinkPreview(content, !isTodoList);
+  const { linkPreviews, setLinkPreviews } = useLinkPreview(content, !isTodoList && !isDemo);
   const {
     todoItems,
     setTodoItems,
@@ -125,7 +128,7 @@ function NoteModal({ note, onSave, onClose, onToggleArchive, onOpenCollaborate, 
       isPinned: isPinned,
       isTodoList: isTodoList,
       todoItems: isTodoList ? getCleanedItems() : [],
-      linkPreviews: linkPreviews || [],
+      linkPreviews: isDemo ? [] : (linkPreviews || []),
     };
 
     setIsSaving(true);
@@ -487,7 +490,7 @@ function NoteModal({ note, onSave, onClose, onToggleArchive, onOpenCollaborate, 
             />
           )}
 
-          {!isTodoList && linkPreviews && linkPreviews.length > 0 && (
+          {!isDemo && !isTodoList && linkPreviews && linkPreviews.length > 0 && (
             <div className="note-modal-link-previews">
               {linkPreviews.map((preview, index) => (
                 <LinkPreview
@@ -501,7 +504,7 @@ function NoteModal({ note, onSave, onClose, onToggleArchive, onOpenCollaborate, 
             </div>
           )}
 
-          {note && images && images.length > 0 && (
+          {!isDemo && note && images && images.length > 0 && (
             <div className="note-modal-images">
               <div className="uploaded-images">
                 {images.map((image, index) => (
@@ -524,7 +527,7 @@ function NoteModal({ note, onSave, onClose, onToggleArchive, onOpenCollaborate, 
             </div>
           )}
 
-          {note && newImageFiles.length > 0 && (
+          {!isDemo && note && newImageFiles.length > 0 && (
             <div className="new-images-preview">
               {newImageFiles.map((file, index) => (
                 <div key={index} className="image-preview new">
@@ -547,7 +550,7 @@ function NoteModal({ note, onSave, onClose, onToggleArchive, onOpenCollaborate, 
           )}
 
           {/* Hidden file input for image selection */}
-          {note && (
+          {!isDemo && note && (
             <input
               ref={fileInputRef}
               type="file"
@@ -668,7 +671,7 @@ function NoteModal({ note, onSave, onClose, onToggleArchive, onOpenCollaborate, 
                 <path d="M12 17v5m-5-9H5a2 2 0 0 1 0-4h14a2 2 0 0 1 0 4h-2m-5-9V2"/>
               </svg>
             </button>
-            {note && (
+            {!isDemo && note && (
               <>
                 <label
                   htmlFor="image-upload-input"
@@ -702,7 +705,7 @@ function NoteModal({ note, onSave, onClose, onToggleArchive, onOpenCollaborate, 
                 )}
               </>
             )}
-            {note && settings.aiFeatures.voiceTranscription && !isTodoList && (
+            {!isDemo && note && settings.aiFeatures.voiceTranscription && !isTodoList && (
               <button
                 type="button"
                 className={`btn-modal-voice ${isRecording ? 'recording' : ''} ${isTranscribing ? 'transcribing' : ''}`}

--- a/client/src/components/Sidebar.css
+++ b/client/src/components/Sidebar.css
@@ -342,6 +342,17 @@
     box-shadow: var(--shadow-sm);
   }
 
+  .sidebar-mobile-user-static {
+    cursor: default;
+  }
+
+  .sidebar-mobile-user-static:hover {
+    background: var(--accent-light);
+    border-color: rgba(196, 120, 93, 0.3);
+    box-shadow: none;
+    transform: none;
+  }
+
   .sidebar-mobile-user:focus-visible {
     outline: 2px solid var(--accent-color);
     outline-offset: 2px;
@@ -386,6 +397,10 @@
     font-size: var(--font-size-base);
     font-weight: var(--font-semibold);
     color: var(--text-primary);
+  }
+
+  .mobile-demo-badge {
+    margin-left: auto;
   }
 
   .sidebar-mobile-actions {

--- a/client/src/components/Sidebar.jsx
+++ b/client/src/components/Sidebar.jsx
@@ -53,17 +53,28 @@ function Sidebar({
           <Logo size={28} />
         </div>
 
-        <button
-          className="sidebar-mobile-user"
-          onClick={() => {
-            onSettingsClick();
-            onMobileClose();
-          }}
-          aria-label="Einstellungen"
-        >
-          <span className="mobile-user-icon">👤</span>
-          <span className="mobile-user-name">{user?.username}</span>
-        </button>
+        {user?.isDemo ? (
+          <div className="sidebar-mobile-user sidebar-mobile-user-static">
+            <svg className="mobile-user-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+              <circle cx="12" cy="8" r="4"/>
+              <path d="M4 21a8 8 0 0116 0"/>
+            </svg>
+            <span className="mobile-user-name">{user?.username}</span>
+            <span className="mobile-demo-badge">{t('demoBadge')}</span>
+          </div>
+        ) : (
+          <button
+            className="sidebar-mobile-user"
+            onClick={() => {
+              onSettingsClick();
+              onMobileClose();
+            }}
+            aria-label="Einstellungen"
+          >
+            <span className="mobile-user-icon">👤</span>
+            <span className="mobile-user-name">{user?.username}</span>
+          </button>
+        )}
 
         <div className="sidebar-mobile-actions">
           <ThemeToggle theme={theme} onToggle={onThemeToggle} />
@@ -116,21 +127,23 @@ function Sidebar({
           <span className="count">{archivedCount || 0}</span>
         </button>
 
-        <button
-          className="sidebar-item"
-          onClick={() => {
-            onOpenFriends();
-            onMobileClose();
-          }}
-          aria-label={t('friends')}
-        >
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-            <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/>
-            <circle cx="9" cy="7" r="4"/>
-            <path d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75"/>
-          </svg>
-          <span>{t('friends')}</span>
-        </button>
+        {onOpenFriends && (
+          <button
+            className="sidebar-item"
+            onClick={() => {
+              onOpenFriends();
+              onMobileClose();
+            }}
+            aria-label={t('friends')}
+          >
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/>
+              <circle cx="9" cy="7" r="4"/>
+              <path d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75"/>
+            </svg>
+            <span>{t('friends')}</span>
+          </button>
+        )}
 
         {allTags.length > 0 && (
           <>

--- a/client/src/constants/api.js
+++ b/client/src/constants/api.js
@@ -15,6 +15,7 @@ export const API_ENDPOINTS = {
     SETUP_NEEDED: '/api/auth/setup-needed',
     REGISTER: '/api/auth/register',
     LOGIN: '/api/auth/login',
+    DEMO: '/api/auth/demo',
     LOGOUT: '/api/auth/logout',
     ME: '/api/auth/me',
     CSRF_TOKEN: '/api/csrf-token',

--- a/client/src/contexts/AuthContext.jsx
+++ b/client/src/contexts/AuthContext.jsx
@@ -58,6 +58,13 @@ export function AuthProvider({ children }) {
     return response;
   };
 
+  const demoLogin = async () => {
+    const response = await authAPI.demoLogin();
+    setUser(response.user);
+    setIsLoggedIn(true);
+    return response;
+  };
+
   const register = async (username, email, password) => {
     const response = await authAPI.register(username, email, password);
     setUser(response.user);
@@ -104,6 +111,7 @@ export function AuthProvider({ children }) {
     loading,
     setupNeeded,
     login,
+    demoLogin,
     register,
     logout,
     setup,

--- a/client/src/services/api/authAPI.js
+++ b/client/src/services/api/authAPI.js
@@ -109,6 +109,33 @@ const authAPI = {
   },
 
   /**
+   * Start an isolated public demo session without exposing shared credentials.
+   * The endpoint only exists when the server explicitly enables demo mode.
+   * @returns {Promise<{user: Object}>} Demo user data
+   * @throws {Error} If demo mode is unavailable or the session cannot be created
+   */
+  demoLogin: async () => {
+    const csrfHeaders = await authCsrfHeaders();
+    const response = await fetch(`${API_BASE_URL}${API_ENDPOINTS.AUTH.DEMO}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...csrfHeaders },
+      credentials: 'include',
+    });
+
+    if (!response.ok) {
+      const error = await parseResponse(response);
+      throw new Error(error.error || ERROR_MESSAGES.LOGIN_FAILED);
+    }
+
+    const data = requireUserPayload(
+      await parseResponse(response),
+      ERROR_MESSAGES.LOGIN_FAILED
+    );
+    await initializeCSRF();
+    return data;
+  },
+
+  /**
    * Logout current user
    * Clears the cookie-backed session and any legacy local token.
    */

--- a/client/src/translations/de.js
+++ b/client/src/translations/de.js
@@ -19,6 +19,17 @@ export const de = {
   orContinueWith: 'oder weiter mit',
   oauthFailed: 'OAuth-Anmeldung fehlgeschlagen. Bitte versuchen Sie es erneut.',
   backToLogin: 'Zurück zur Anmeldung',
+  publicDemo: 'Öffentliche Demo',
+  demoIntroTitle: 'Direkt ausprobieren',
+  demoIntroBody: 'Gemeinsamer öffentlicher Bereich: Bitte keine persönlichen oder vertraulichen Daten eingeben. Änderungen sind für andere Tester sichtbar und werden alle 6 Stunden zurückgesetzt. Uploads, KI und Zusammenarbeit sind deaktiviert.',
+  demoTryNow: 'Demo ausprobieren',
+  demoEntering: 'Demo wird geöffnet...',
+  demoLoginFailed: 'Die Demo konnte nicht gestartet werden',
+  demoBadge: 'Demo',
+  demoBannerTitle: 'Öffentliche Demo',
+  demoBannerPrivacy: 'Gemeinsamer Bereich: Keine persönlichen oder vertraulichen Daten eingeben. Änderungen sind für andere Tester sichtbar.',
+  demoBannerRestrictions: 'Uploads, KI und Zusammenarbeit sind deaktiviert.',
+  demoBannerReset: 'Daten werden alle 6 Stunden zurückgesetzt.',
 
   // Setup
   setupTitle: 'KeepLocal Ersteinrichtung',

--- a/client/src/translations/en.js
+++ b/client/src/translations/en.js
@@ -19,6 +19,17 @@ export const en = {
   orContinueWith: 'or continue with',
   oauthFailed: 'OAuth login failed. Please try again.',
   backToLogin: 'Back to Login',
+  publicDemo: 'Public demo',
+  demoIntroTitle: 'Try it right away',
+  demoIntroBody: 'Shared public space: Do not enter personal or confidential information. Changes are visible to other testers and reset every 6 hours. Uploads, AI, and collaboration are disabled.',
+  demoTryNow: 'Try the demo',
+  demoEntering: 'Opening demo...',
+  demoLoginFailed: 'The demo could not be started',
+  demoBadge: 'Demo',
+  demoBannerTitle: 'Public demo',
+  demoBannerPrivacy: 'Shared space: Do not enter personal or confidential information. Changes are visible to other testers.',
+  demoBannerRestrictions: 'Uploads, AI, and collaboration are disabled.',
+  demoBannerReset: 'Data resets every 6 hours.',
 
   // Setup
   setupTitle: 'KeepLocal Initial Setup',

--- a/client/tests/publicDemoMode.test.js
+++ b/client/tests/publicDemoMode.test.js
@@ -1,0 +1,69 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const clientRoot = path.join(__dirname, '..');
+
+function readClientFile(...parts) {
+  return fs.readFileSync(path.join(clientRoot, ...parts), 'utf8');
+}
+
+test('demo login uses the cookie and CSRF protected auth flow', () => {
+  const endpoints = readClientFile('src/constants/api.js');
+  const api = readClientFile('src/services/api/authAPI.js');
+  const context = readClientFile('src/contexts/AuthContext.jsx');
+
+  assert.match(endpoints, /DEMO:\s*['"]\/api\/auth\/demo['"]/);
+  assert.match(api, /demoLogin:\s*async\s*\(\)\s*=>/);
+  assert.match(api, /API_ENDPOINTS\.AUTH\.DEMO/);
+  assert.match(api, /method:\s*['"]POST['"]/);
+  assert.match(api, /credentials:\s*['"]include['"]/);
+  assert.match(api, /authCsrfHeaders\(\)/);
+  assert.match(api, /requireUserPayload/);
+  assert.match(context, /const demoLogin = async \(\) =>/);
+  assert.match(context, /setUser\(response\.user\)/);
+});
+
+test('the public demo entry is discovered from providers and warns about shared data', () => {
+  const login = readClientFile('src/components/Login.jsx');
+  const de = readClientFile('src/translations/de.js');
+  const en = readClientFile('src/translations/en.js');
+
+  assert.match(login, /demo:\s*false/);
+  assert.match(login, /oauthProviders\.demo && onDemoLogin/);
+  assert.match(login, /className="demo-login-button"/);
+  assert.match(login, /aria-describedby="demo-login-description"/);
+  assert.match(de, /keine persönlichen oder vertraulichen Daten/i);
+  assert.match(de, /für andere Tester sichtbar/i);
+  assert.match(en, /do not enter personal or confidential information/i);
+  assert.match(en, /visible to other testers/i);
+});
+
+test('authenticated demo mode stays visibly labelled and removes restricted entry points', () => {
+  const app = readClientFile('src/App.jsx');
+  const sidebar = readClientFile('src/components/Sidebar.jsx');
+  const note = readClientFile('src/components/Note.jsx');
+  const modal = readClientFile('src/components/NoteModal.jsx');
+
+  assert.match(app, /user\?\.isDemo && \(\s*<section className="demo-banner"/);
+  assert.match(app, /t\('demoBannerPrivacy'\)/);
+  assert.match(app, /onSettingsClick=\{user\?\.isDemo \? undefined/);
+  assert.match(app, /onOpenFriends=\{user\?\.isDemo \? undefined/);
+  assert.match(app, /onOpenCollaborate=\{user\?\.isDemo \? undefined/);
+  assert.match(app, /showSettings && !user\?\.isDemo/);
+  assert.match(sidebar, /\{onOpenFriends && \(/);
+  assert.match(note, /\{onOpenCollaborate && \(/);
+  assert.match(modal, /useLinkPreview\(content, !isTodoList && !isDemo\)/);
+  assert.match(modal, /!isDemo && note && images/);
+  assert.match(modal, /!isDemo && note && settings\.aiFeatures\.voiceTranscription/);
+});
+
+test('demo call to action has a visible keyboard focus treatment', () => {
+  const css = readClientFile('src/components/Auth.css');
+  const match = css.match(/\.demo-login-button:focus-visible\s*\{([^}]*)\}/m);
+
+  assert.ok(match, 'demo login focus-visible rule is missing');
+  assert.match(match[1], /outline:\s*3px solid #49B6E5/);
+  assert.match(match[1], /outline-offset:\s*3px/);
+});

--- a/client/tests/vercelDeployment.test.js
+++ b/client/tests/vercelDeployment.test.js
@@ -6,15 +6,43 @@ const { pathToFileURL } = require('node:url');
 
 const root = path.resolve(__dirname, '..');
 
-test('Vercel has an explicit Vite build contract and OAuth callback rewrite', () => {
+test('Vercel has an explicit Vite build contract and same-origin demo proxy', () => {
   const config = JSON.parse(fs.readFileSync(path.join(root, 'vercel.json'), 'utf8'));
 
   assert.equal(config.framework, 'vite');
   assert.equal(config.buildCommand, 'npm run build');
   assert.equal(config.outputDirectory, 'build');
   assert.deepEqual(config.rewrites, [
+    {
+      source: '/api/:path*',
+      destination: 'https://keeplocal-demo.zwaetschge-webui.ch/api/:path*',
+    },
+    {
+      source: '/uploads/:path*',
+      destination: 'https://keeplocal-demo.zwaetschge-webui.ch/uploads/:path*',
+    },
     { source: '/oauth/callback', destination: '/index.html' },
   ]);
+});
+
+test('Vercel applies static security headers and never caches private demo data', () => {
+  const config = JSON.parse(fs.readFileSync(path.join(root, 'vercel.json'), 'utf8'));
+  const globalHeaders = config.headers.find(({ source }) => source === '/(.*)')?.headers || [];
+  const asMap = (headers) => Object.fromEntries(headers.map(({ key, value }) => [key, value]));
+  const security = asMap(globalHeaders);
+
+  assert.match(security['Content-Security-Policy'], /default-src 'self'/);
+  assert.match(security['Content-Security-Policy'], /connect-src 'self'/);
+  assert.match(security['Content-Security-Policy'], /frame-ancestors 'self'/);
+  assert.equal(security['X-Frame-Options'], 'SAMEORIGIN');
+  assert.equal(security['X-Content-Type-Options'], 'nosniff');
+  assert.equal(security['Referrer-Policy'], 'strict-origin-when-cross-origin');
+  assert.equal(security['Permissions-Policy'], 'camera=(), microphone=(self), geolocation=()');
+
+  for (const source of ['/api/:path*', '/uploads/:path*']) {
+    const privateHeaders = config.headers.find((entry) => entry.source === source)?.headers || [];
+    assert.match(asMap(privateHeaders)['Cache-Control'], /\bno-store\b/);
+  }
 });
 
 test('Vite exposes the legacy API URL without exposing arbitrary environment variables', async () => {

--- a/client/vercel.json
+++ b/client/vercel.json
@@ -5,8 +5,61 @@
   "outputDirectory": "build",
   "rewrites": [
     {
+      "source": "/api/:path*",
+      "destination": "https://keeplocal-demo.zwaetschge-webui.ch/api/:path*"
+    },
+    {
+      "source": "/uploads/:path*",
+      "destination": "https://keeplocal-demo.zwaetschge-webui.ch/uploads/:path*"
+    },
+    {
       "source": "/oauth/callback",
       "destination": "/index.html"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; media-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'self'; form-action 'self'"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "SAMEORIGIN"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(self), geolocation=()"
+        }
+      ]
+    },
+    {
+      "source": "/api/:path*",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "private, no-store, max-age=0"
+        }
+      ]
+    },
+    {
+      "source": "/uploads/:path*",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "private, no-store, max-age=0"
+        }
+      ]
     }
   ]
 }

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,0 +1,56 @@
+name: keeplocal-demo
+
+services:
+  keeplocal-demo:
+    # Use a multi-architecture manifest digest, never a mutable tag such as latest.
+    image: ${KEEPLOCAL_DEMO_IMAGE:?KEEPLOCAL_DEMO_IMAGE must be an immutable image reference ending in @sha256:<digest>}
+    pull_policy: always
+    container_name: keeplocal-demo
+    restart: unless-stopped
+    environment:
+      NODE_ENV: production
+      PORT: 5000
+      HOST: 127.0.0.1
+      MONGODB_URI: mongodb://localhost:27017/keeplocal-demo
+      JWT_SECRET: ${JWT_SECRET:?JWT_SECRET must contain at least 32 random characters}
+      JWT_EXPIRES_IN: ${JWT_EXPIRES_IN:-1d}
+      CSRF_SECRET: ${CSRF_SECRET:?CSRF_SECRET must contain at least 32 random characters}
+      COOKIE_SECURE: "true"
+      ALLOWED_ORIGINS: https://keep-local-silk.vercel.app
+      TRUST_PROXY: "2"
+      CLIENT_URL: https://keep-local-silk.vercel.app
+      WHISPER_MODEL: ${WHISPER_MODEL:-tiny}
+      DEMO_MODE: "true"
+      DEMO_RESET_INTERVAL_HOURS: ${DEMO_RESET_INTERVAL_HOURS:-6}
+      DEMO_NOTE_LIMIT: ${DEMO_NOTE_LIMIT:-100}
+      GOOGLE_CLIENT_ID: ""
+      GOOGLE_CLIENT_SECRET: ""
+      GOOGLE_CALLBACK_URL: ""
+      GITHUB_CLIENT_ID: ""
+      GITHUB_CLIENT_SECRET: ""
+      GITHUB_CALLBACK_URL: ""
+    volumes:
+      - /mnt/user/appdata/keeplocal-demo/mongodb:/data/db
+      - /mnt/user/appdata/keeplocal-demo/uploads:/app/server/uploads
+    networks:
+      - brian_traefik-public
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    labels:
+      traefik.enable: ${TRAEFIK_ENABLE:-false}
+      traefik.docker.network: brian_traefik-public
+      traefik.http.routers.keeplocal-demo.rule: Host(`keeplocal-demo.zwaetschge-webui.ch`) && (Path(`/api`) || PathPrefix(`/api/`) || Path(`/uploads`) || PathPrefix(`/uploads/`))
+      traefik.http.routers.keeplocal-demo.entrypoints: websecure
+      traefik.http.routers.keeplocal-demo.tls: "true"
+      traefik.http.routers.keeplocal-demo.tls.certresolver: cloudflare
+      traefik.http.routers.keeplocal-demo.middlewares: security-headers@file
+      traefik.http.routers.keeplocal-demo.service: keeplocal-demo
+      traefik.http.services.keeplocal-demo.loadbalancer.server.port: "80"
+
+networks:
+  brian_traefik-public:
+    external: true

--- a/server/middleware/demoPolicy.js
+++ b/server/middleware/demoPolicy.js
@@ -1,0 +1,112 @@
+const Note = require('../models/Note');
+
+const DEMO_FEATURE_ERROR = 'Diese Funktion ist in der oeffentlichen Demo deaktiviert.';
+const DEFAULT_DEMO_NOTE_LIMIT = 100;
+const MAX_DEMO_NOTE_LIMIT = 500;
+let demoNoteCreationQueue = Promise.resolve();
+
+function isDemoMode(environment = process.env) {
+  return environment.DEMO_MODE === 'true';
+}
+
+function parseDemoNoteLimit(value = process.env.DEMO_NOTE_LIMIT) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return DEFAULT_DEMO_NOTE_LIMIT;
+  }
+  return Math.min(parsed, MAX_DEMO_NOTE_LIMIT);
+}
+
+function demoFeatureDisabled(res, feature) {
+  return res.status(403).json({
+    error: DEMO_FEATURE_ERROR,
+    code: 'DEMO_FEATURE_DISABLED',
+    feature
+  });
+}
+
+function blockDemoUser(feature) {
+  return (req, res, next) => {
+    if (!req.user?.isDemo) return next();
+    return demoFeatureDisabled(res, feature);
+  };
+}
+
+function rejectDemoNoteCapabilities(req, res, next) {
+  if (!req.user?.isDemo) return next();
+
+  const body = req.body && typeof req.body === 'object' ? req.body : {};
+  const hasLinkPreviews = Array.isArray(body.linkPreviews) && body.linkPreviews.length > 0;
+  const hasRestrictedData = hasLinkPreviews ||
+    Object.prototype.hasOwnProperty.call(body, 'images') ||
+    Object.prototype.hasOwnProperty.call(body, 'sharedWith');
+
+  if (hasRestrictedData) {
+    return demoFeatureDisabled(res, 'note_attachments');
+  }
+  return next();
+}
+
+function createDemoNoteLimitMiddleware(countDocuments = (query) => Note.countDocuments(query)) {
+  return async (req, res, next) => {
+    if (!req.user?.isDemo) return next();
+
+    let releaseQueue;
+    const previousRequest = demoNoteCreationQueue;
+    demoNoteCreationQueue = new Promise(resolve => {
+      releaseQueue = resolve;
+    });
+    await previousRequest;
+
+    let released = false;
+    const release = () => {
+      if (released) return;
+      released = true;
+      releaseQueue();
+    };
+
+    try {
+      const noteCount = await countDocuments({ userId: req.user._id });
+      const limit = parseDemoNoteLimit();
+      if (noteCount >= limit) {
+        release();
+        return res.status(429).json({
+          error: `Die oeffentliche Demo ist auf ${limit} Notizen begrenzt.`,
+          code: 'DEMO_NOTE_LIMIT'
+        });
+      }
+
+      // The all-in-one demo has one Node process. Holding this small queue
+      // until the response finishes keeps parallel creates from all observing
+      // the same pre-insert count and bursting past the quota.
+      if (typeof res.once === 'function') {
+        res.once('finish', release);
+        res.once('close', release);
+      } else {
+        release();
+      }
+      return next();
+    } catch (error) {
+      release();
+      return next(error);
+    }
+  };
+}
+
+const enforceDemoNoteLimit = createDemoNoteLimitMiddleware();
+
+function shouldRevokeAllSessionsOnLogout(user) {
+  return Boolean(user && !user.isDemo);
+}
+
+module.exports = {
+  DEFAULT_DEMO_NOTE_LIMIT,
+  DEMO_FEATURE_ERROR,
+  blockDemoUser,
+  createDemoNoteLimitMiddleware,
+  enforceDemoNoteLimit,
+  isDemoMode,
+  parseDemoNoteLimit,
+  rejectDemoNoteCapabilities,
+  shouldRevokeAllSessionsOnLogout
+};

--- a/server/middleware/noStore.js
+++ b/server/middleware/noStore.js
@@ -1,0 +1,8 @@
+function noStore(req, res, next) {
+  res.setHeader('Cache-Control', 'private, no-store, max-age=0');
+  res.setHeader('Pragma', 'no-cache');
+  res.setHeader('Expires', '0');
+  next();
+}
+
+module.exports = noStore;

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -43,6 +43,10 @@ const userSchema = new mongoose.Schema({
     type: Boolean,
     default: false
   },
+  isDemo: {
+    type: Boolean,
+    default: false
+  },
   isBootstrapAdmin: {
     type: Boolean,
     default: false,
@@ -92,6 +96,17 @@ userSchema.index(
     name: 'single_bootstrap_admin',
     unique: true,
     partialFilterExpression: { isBootstrapAdmin: true }
+  }
+);
+
+// Public demo deployments use exactly one deliberately restricted account.
+// The partial index leaves all normal users unaffected.
+userSchema.index(
+  { isDemo: 1 },
+  {
+    name: 'single_demo_user',
+    unique: true,
+    partialFilterExpression: { isDemo: true }
   }
 );
 

--- a/server/routes/apiKeys.js
+++ b/server/routes/apiKeys.js
@@ -9,9 +9,11 @@ const router = express.Router();
 const mongoose = require('mongoose');
 const ApiKey = require('../models/ApiKey');
 const { authenticateToken } = require('../middleware/auth');
+const { blockDemoUser } = require('../middleware/demoPolicy');
 
 // All routes require JWT authentication
 router.use(authenticateToken);
+router.use(blockDemoUser('api_keys'));
 
 /**
  * @swagger

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -17,9 +17,31 @@ const {
 const { clearCsrfCookie } = require('../middleware/csrfProtection');
 const { publicValidationErrors } = require('../utils/validationErrors');
 const { getClientURL } = require('../utils/clientUrl');
+const {
+  isDemoMode,
+  shouldRevokeAllSessionsOnLogout
+} = require('../middleware/demoPolicy');
 
 const OAUTH_STATE_COOKIE = 'kl_oauth_state';
 const DUMMY_PASSWORD_HASH = '$2a$10$DOhqVvnjClITTjb5w5ae/exBwouYnqW5CmBHs1IPa3CH1LrXLpB3S';
+
+function publicAuthUser(user, includeProfile = false) {
+  const payload = {
+    id: user._id,
+    username: user.username,
+    email: user.email,
+    isAdmin: user.isAdmin,
+    isDemo: user.isDemo === true
+  };
+
+  if (includeProfile) {
+    payload.provider = user.provider || 'local';
+    payload.avatar = user.avatar || null;
+    payload.createdAt = user.createdAt;
+  }
+
+  return payload;
+}
 
 // Validation error handler
 const handleValidationErrors = (req, res, next) => {
@@ -36,6 +58,13 @@ const handleValidationErrors = (req, res, next) => {
 // GET /api/auth/setup-needed - Check if initial setup is required
 router.get('/setup-needed', async (req, res) => {
   try {
+    if (isDemoMode()) {
+      return res.json({
+        setupNeeded: false,
+        message: 'System already configured'
+      });
+    }
+
     const userCount = await User.countDocuments();
     res.json({
       setupNeeded: userCount === 0,
@@ -50,6 +79,10 @@ router.get('/setup-needed', async (req, res) => {
 // GET /api/auth/registration-status - Check if registration is enabled
 router.get('/registration-status', async (req, res) => {
   try {
+    if (isDemoMode()) {
+      return res.json({ registrationEnabled: false });
+    }
+
     const userCount = await User.countDocuments();
 
     // If no users exist, registration is always allowed (first admin)
@@ -99,6 +132,12 @@ router.post('/register', [
   handleValidationErrors
 ], async (req, res, next) => {
   try {
+    if (isDemoMode()) {
+      return res.status(403).json({
+        error: 'Registrierung ist in der oeffentlichen Demo deaktiviert.'
+      });
+    }
+
     const { username, email, password } = req.body;
 
     // Check if this is the first user (admin)
@@ -148,12 +187,7 @@ router.post('/register', [
 
     res.status(201).json({
       message: 'Registrierung erfolgreich',
-      user: {
-        id: user._id,
-        username: user.username,
-        email: user.email,
-        isAdmin: user.isAdmin
-      }
+      user: publicAuthUser(user)
     });
   } catch (error) {
     if (error.code === 11000) {
@@ -199,37 +233,56 @@ router.post('/login', [
 
     res.json({
       message: 'Anmeldung erfolgreich',
-      user: {
-        id: user._id,
-        username: user.username,
-        email: user.email,
-        isAdmin: user.isAdmin
-      }
+      user: publicAuthUser(user)
     });
   } catch (error) {
     next(error);
   }
 });
 
+// POST /api/auth/demo - Start a session for the deliberately restricted
+// public demo account. There is no shared public password to leak or reuse.
+router.post('/demo', async (req, res, next) => {
+  try {
+    if (!isDemoMode()) {
+      return res.status(404).json({ error: 'Demo ist nicht aktiviert' });
+    }
+
+    const user = await User.findOne({ isDemo: true, isAdmin: false, provider: 'local' })
+      .select('+sessionVersion');
+
+    if (!user) {
+      return res.status(503).json({
+        error: 'Demo wird gerade vorbereitet. Bitte versuche es gleich erneut.',
+        code: 'DEMO_NOT_READY'
+      });
+    }
+
+    const token = generateToken(user._id, user.sessionVersion);
+    setAuthCookie(res, token);
+
+    return res.json({
+      message: 'Demo gestartet',
+      user: publicAuthUser(user)
+    });
+  } catch (error) {
+    return next(error);
+  }
+});
+
 // GET /api/auth/me - Aktuellen Benutzer abrufen
 router.get('/me', authenticateToken, async (req, res) => {
   res.json({
-    user: {
-      id: req.user._id,
-      username: req.user.username,
-      email: req.user.email,
-      isAdmin: req.user.isAdmin,
-      provider: req.user.provider || 'local',
-      avatar: req.user.avatar || null,
-      createdAt: req.user.createdAt
-    }
+    user: publicAuthUser(req.user, true)
   });
 });
 
-// POST /api/auth/logout - Browser session and all copies of its JWT are revoked.
+// POST /api/auth/logout - Normal accounts revoke every copy of the current
+// session. The shared demo only clears this browser so one visitor cannot log
+// out everybody else.
 router.post('/logout', optionalAuth, async (req, res, next) => {
   try {
-    if (req.user) {
+    if (shouldRevokeAllSessionsOnLogout(req.user)) {
       await User.updateOne(
         { _id: req.user._id, sessionVersion: req.user.sessionVersion },
         { $inc: { sessionVersion: 1 } }
@@ -247,10 +300,12 @@ router.post('/logout', optionalAuth, async (req, res, next) => {
 
 // GET /api/auth/providers - Return which OAuth providers are configured
 router.get('/providers', (req, res) => {
+  const demo = isDemoMode();
   res.json({
     providers: {
-      google: !!(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET),
-      github: !!(process.env.GITHUB_CLIENT_ID && process.env.GITHUB_CLIENT_SECRET),
+      google: !demo && !!(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET),
+      github: !demo && !!(process.env.GITHUB_CLIENT_ID && process.env.GITHUB_CLIENT_SECRET),
+      demo
     }
   });
 });
@@ -290,6 +345,13 @@ function issueOAuthState(req, res, next) {
   next();
 }
 
+function rejectOAuthInDemo(req, res, next) {
+  if (isDemoMode()) {
+    return res.status(404).json({ error: 'OAuth ist in der Demo nicht konfiguriert' });
+  }
+  return next();
+}
+
 function validateOAuthState(req, res, next) {
   const expected = req.cookies?.[OAUTH_STATE_COOKIE];
   const actual = req.query.state;
@@ -312,7 +374,7 @@ function validateOAuthState(req, res, next) {
 // --- Google OAuth ---
 router.get('/google',
   (req, res, next) => {
-    if (!process.env.GOOGLE_CLIENT_ID) {
+    if (isDemoMode() || !process.env.GOOGLE_CLIENT_ID) {
       return res.status(404).json({ error: 'Google OAuth is not configured' });
     }
     next();
@@ -326,6 +388,7 @@ router.get('/google',
 );
 
 router.get('/google/callback',
+  rejectOAuthInDemo,
   validateOAuthState,
   authenticateOAuthCallback('google', 'google_auth_failed')
 );
@@ -333,7 +396,7 @@ router.get('/google/callback',
 // --- GitHub OAuth ---
 router.get('/github',
   (req, res, next) => {
-    if (!process.env.GITHUB_CLIENT_ID) {
+    if (isDemoMode() || !process.env.GITHUB_CLIENT_ID) {
       return res.status(404).json({ error: 'GitHub OAuth is not configured' });
     }
     next();
@@ -347,6 +410,7 @@ router.get('/github',
 );
 
 router.get('/github/callback',
+  rejectOAuthInDemo,
   validateOAuthState,
   authenticateOAuthCallback('github', 'github_auth_failed')
 );

--- a/server/routes/friends.js
+++ b/server/routes/friends.js
@@ -4,9 +4,11 @@ const mongoose = require('mongoose');
 const User = require('../models/User');
 const { authenticateToken } = require('../middleware/auth');
 const { escapeRegex } = require('../utils/sanitize');
+const { blockDemoUser } = require('../middleware/demoPolicy');
 
 // Alle Routen erfordern Authentifizierung
 router.use(authenticateToken);
+router.use(blockDemoUser('collaboration'));
 
 // GET /api/friends - Alle Freunde abrufen
 router.get('/', async (req, res, next) => {

--- a/server/routes/notes.js
+++ b/server/routes/notes.js
@@ -14,6 +14,16 @@ const { validateImageFiles, validateAudioFile } = require('../utils/magicNumberV
 const notesService = require('../services/notesService');
 const aiService = require('../services/aiService');
 const { httpStatus } = require('../constants');
+const {
+  blockDemoUser,
+  enforceDemoNoteLimit,
+  rejectDemoNoteCapabilities
+} = require('../middleware/demoPolicy');
+
+const blockDemoCollaboration = blockDemoUser('collaboration');
+const blockDemoLinkPreview = blockDemoUser('link_preview');
+const blockDemoUploads = blockDemoUser('uploads');
+const blockDemoTranscription = blockDemoUser('transcription');
 
 // All routes require authentication
 router.use(authenticateToken);
@@ -70,22 +80,28 @@ router.get('/:id', noteValidation.getOne, async (req, res, next) => {
 /**
  * POST /api/notes - Create a new note
  */
-router.post('/', noteValidation.create, async (req, res, next) => {
-  try {
-    const savedNote = await notesService.createNote(req.body, req.user._id);
-    res.status(httpStatus.CREATED).json(savedNote);
-  } catch (error) {
-    if (error.name === 'ValidationError') {
-      return res.status(httpStatus.BAD_REQUEST).json({ error: error.message });
+router.post(
+  '/',
+  noteValidation.create,
+  rejectDemoNoteCapabilities,
+  enforceDemoNoteLimit,
+  async (req, res, next) => {
+    try {
+      const savedNote = await notesService.createNote(req.body, req.user._id);
+      res.status(httpStatus.CREATED).json(savedNote);
+    } catch (error) {
+      if (error.name === 'ValidationError') {
+        return res.status(httpStatus.BAD_REQUEST).json({ error: error.message });
+      }
+      next(error);
     }
-    next(error);
   }
-});
+);
 
 /**
  * PUT /api/notes/:id - Update an existing note
  */
-router.put('/:id', noteValidation.update, async (req, res, next) => {
+router.put('/:id', noteValidation.update, rejectDemoNoteCapabilities, async (req, res, next) => {
   try {
     const updatedNote = await notesService.updateNote(
       req.params.id,
@@ -155,7 +171,7 @@ router.post('/:id/archive', noteValidation.pin, async (req, res, next) => {
 /**
  * POST /api/notes/:id/share - Share a note with another user
  */
-router.post('/:id/share', async (req, res, next) => {
+router.post('/:id/share', blockDemoCollaboration, async (req, res, next) => {
   try {
     const { userId: targetUserId } = req.body;
     if (!targetUserId || !/^[a-f\d]{24}$/i.test(targetUserId)) {
@@ -178,7 +194,7 @@ router.post('/:id/share', async (req, res, next) => {
 /**
  * DELETE /api/notes/:id/share/:userId - Unshare a note from a user
  */
-router.delete('/:id/share/:userId', async (req, res, next) => {
+router.delete('/:id/share/:userId', blockDemoCollaboration, async (req, res, next) => {
   try {
     const note = await notesService.unshareNote(
       req.params.id,
@@ -197,7 +213,7 @@ router.delete('/:id/share/:userId', async (req, res, next) => {
 /**
  * POST /api/notes/link-preview - Fetch link preview for a URL
  */
-router.post('/link-preview', async (req, res, next) => {
+router.post('/link-preview', blockDemoLinkPreview, async (req, res, next) => {
   try {
     const { url } = req.body;
 
@@ -222,7 +238,7 @@ router.post('/link-preview', async (req, res, next) => {
  * POST /api/notes/:id/images - Upload images to a note
  * Supports multiple files (max 5 images per request)
  */
-router.post('/:id/images', noteValidation.getOne, requireOwnedNote, (req, res, next) => {
+router.post('/:id/images', blockDemoUploads, noteValidation.getOne, requireOwnedNote, (req, res, next) => {
   if ((req.ownedNote.images?.length || 0) >= 25) {
     return res.status(httpStatus.BAD_REQUEST).json({ error: 'Maximal 25 Bilder pro Notiz erlaubt' });
   }
@@ -353,7 +369,7 @@ router.post('/:id/images', noteValidation.getOne, requireOwnedNote, (req, res, n
 /**
  * DELETE /api/notes/:id/images/:filename - Delete an image from a note
  */
-router.delete('/:id/images/:filename', noteValidation.getOne, async (req, res, next) => {
+router.delete('/:id/images/:filename', blockDemoUploads, noteValidation.getOne, async (req, res, next) => {
   try {
     if (!isSafeStoredFilename(req.params.filename)) {
       return res.status(httpStatus.BAD_REQUEST).json({ error: 'Ungueltiger Dateiname' });
@@ -400,7 +416,7 @@ router.delete('/:id/images/:filename', noteValidation.getOne, async (req, res, n
  * POST /api/notes/:id/transcribe - Upload audio and append transcription to note
  * Uses Whisper AI service to convert speech to text
  */
-router.post('/:id/transcribe', noteValidation.getOne, requireOwnedNote, (req, res, next) => {
+router.post('/:id/transcribe', blockDemoTranscription, noteValidation.getOne, requireOwnedNote, (req, res, next) => {
   uploadAudio.single('audio')(req, res, (err) => {
     if (err) {
       if (err.code === 'LIMIT_FILE_SIZE') {

--- a/server/scripts/demoReset.js
+++ b/server/scripts/demoReset.js
@@ -1,0 +1,278 @@
+const crypto = require('crypto');
+const mongoose = require('mongoose');
+const ApiKey = require('../models/ApiKey');
+const Note = require('../models/Note');
+const Settings = require('../models/Settings');
+const User = require('../models/User');
+const { isDemoMode } = require('../middleware/demoPolicy');
+
+const DEFAULT_RESET_INTERVAL_HOURS = 6;
+const MAX_RESET_INTERVAL_HOURS = 168;
+const DEMO_NOTE_IDS = [
+  '66d000000000000000000001',
+  '66d000000000000000000002',
+  '66d000000000000000000003',
+  '66d000000000000000000004'
+];
+
+function parseResetIntervalHours(value) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) return DEFAULT_RESET_INTERVAL_HOURS;
+  return Math.min(parsed, MAX_RESET_INTERVAL_HOURS);
+}
+
+function getDemoConfig(environment = process.env) {
+  const username = (environment.DEMO_USERNAME || 'demo').trim();
+  const email = (environment.DEMO_USER_EMAIL || 'demo@keeplocal.invalid').trim().toLowerCase();
+
+  if (!/^[a-zA-Z0-9_-]{3,50}$/.test(username)) {
+    throw new Error('DEMO_USERNAME must contain 3 to 50 safe characters');
+  }
+  if (!/^\S+@\S+\.\S+$/.test(email)) {
+    throw new Error('DEMO_USER_EMAIL must be a valid email address');
+  }
+
+  return {
+    username,
+    email,
+    resetIntervalHours: parseResetIntervalHours(environment.DEMO_RESET_INTERVAL_HOURS)
+  };
+}
+
+function buildDemoFixtures(userId, referenceTime = new Date()) {
+  const timestamp = new Date(referenceTime);
+  if (Number.isNaN(timestamp.getTime())) {
+    throw new Error('A valid reference time is required');
+  }
+
+  const createdAt = (minutesAgo) => new Date(timestamp.getTime() - minutesAgo * 60 * 1000);
+
+  return [
+    {
+      _id: new mongoose.Types.ObjectId(DEMO_NOTE_IDS[0]),
+      title: 'Willkommen bei KeepLocal',
+      content: 'Diese oeffentliche Demo zeigt dir die wichtigsten Notizfunktionen. Probiere Farben, Tags, Suche, Anheften und Archivieren aus.',
+      color: '#aecbfa',
+      isPinned: true,
+      isArchived: false,
+      tags: ['demo', 'willkommen'],
+      images: [],
+      isTodoList: false,
+      todoItems: [],
+      linkPreviews: [],
+      userId,
+      sharedWith: [],
+      createdAt: createdAt(40),
+      updatedAt: createdAt(40)
+    },
+    {
+      _id: new mongoose.Types.ObjectId(DEMO_NOTE_IDS[1]),
+      title: 'Ideen fuer den Wochenendausflug',
+      content: 'Picknick am See\nKleine Wanderung\nKamera und Kartenspiel einpacken',
+      color: '#fff475',
+      isPinned: false,
+      isArchived: false,
+      tags: ['ideen', 'privat'],
+      images: [],
+      isTodoList: false,
+      todoItems: [],
+      linkPreviews: [],
+      userId,
+      sharedWith: [],
+      createdAt: createdAt(30),
+      updatedAt: createdAt(30)
+    },
+    {
+      _id: new mongoose.Types.ObjectId(DEMO_NOTE_IDS[2]),
+      title: 'Demo-Checkliste',
+      content: '',
+      color: '#ccff90',
+      isPinned: false,
+      isArchived: false,
+      tags: ['demo', 'todo'],
+      images: [],
+      isTodoList: true,
+      todoItems: [
+        { text: 'Eine neue Notiz anlegen', completed: true, order: 0 },
+        { text: 'Eine Farbe auswaehlen', completed: false, order: 1 },
+        { text: 'Nach einem Tag filtern', completed: false, order: 2 }
+      ],
+      linkPreviews: [],
+      userId,
+      sharedWith: [],
+      createdAt: createdAt(20),
+      updatedAt: createdAt(20)
+    },
+    {
+      _id: new mongoose.Types.ObjectId(DEMO_NOTE_IDS[3]),
+      title: 'Archivierte Beispielnotiz',
+      content: 'Archivierte Notizen bleiben erhalten und koennen jederzeit wiederhergestellt werden.',
+      color: '#e8eaed',
+      isPinned: false,
+      isArchived: true,
+      tags: ['archiv'],
+      images: [],
+      isTodoList: false,
+      todoItems: [],
+      linkPreviews: [],
+      userId,
+      sharedWith: [],
+      createdAt: createdAt(10),
+      updatedAt: createdAt(10)
+    }
+  ];
+}
+
+function generateInternalPassword() {
+  // The password is never printed or exposed. Public entry uses /api/auth/demo.
+  return `${crypto.randomBytes(48).toString('base64url')}Aa1`;
+}
+
+async function inspectDemoDatabase(config) {
+  const users = await User.find({}).select('+isBootstrapAdmin +sessionVersion');
+  const unexpectedUser = users.find(user => !user.isDemo);
+  if (unexpectedUser) {
+    throw new Error('Demo reset refused: the database contains a non-demo user');
+  }
+  if (users.length > 1) {
+    throw new Error('Demo reset refused: the database contains multiple demo users');
+  }
+
+  const user = users[0] || null;
+  if (user && (
+    user.username !== config.username ||
+    user.email !== config.email ||
+    user.provider !== 'local' ||
+    user.providerId !== null ||
+    user.isAdmin ||
+    user.isBootstrapAdmin
+  )) {
+    throw new Error('Demo reset refused: the demo account identity or role is unexpected');
+  }
+
+  const unexpectedNotes = user
+    ? await Note.countDocuments({ userId: { $ne: user._id } })
+    : await Note.countDocuments({});
+  const unexpectedApiKeys = user
+    ? await ApiKey.countDocuments({ userId: { $ne: user._id } })
+    : await ApiKey.countDocuments({});
+
+  if (unexpectedNotes || unexpectedApiKeys) {
+    throw new Error('Demo reset refused: the database contains data outside the demo account');
+  }
+
+  return user;
+}
+
+async function createDemoUser(config) {
+  const user = new User({
+    username: config.username,
+    email: config.email,
+    password: generateInternalPassword(),
+    provider: 'local',
+    isAdmin: false,
+    isDemo: true,
+    isBootstrapAdmin: false,
+    friends: [],
+    friendRequests: []
+  });
+  await user.save();
+  return user;
+}
+
+async function resetDemoData(config = getDemoConfig(), referenceTime = new Date()) {
+  let user = await inspectDemoDatabase(config);
+  if (!user) user = await createDemoUser(config);
+
+  await User.updateOne(
+    { _id: user._id, isDemo: true },
+    {
+      $set: {
+        isAdmin: false,
+        isBootstrapAdmin: false,
+        friends: [],
+        friendRequests: []
+      },
+      $inc: { sessionVersion: 1 }
+    }
+  );
+
+  await Promise.all([
+    ApiKey.deleteMany({ userId: user._id }),
+    Settings.updateOne(
+      { _id: '1' },
+      { $set: { registrationEnabled: false, updatedAt: new Date(referenceTime) } },
+      { upsert: true }
+    )
+  ]);
+
+  await Note.deleteMany({ userId: user._id });
+  const fixtures = buildDemoFixtures(user._id, referenceTime);
+  await Note.insertMany(fixtures, { ordered: true });
+
+  return { userId: user._id, noteCount: fixtures.length };
+}
+
+async function connectWithRetry(maxAttempts = 30, delayMs = 2000) {
+  if (!process.env.MONGODB_URI) {
+    throw new Error('MONGODB_URI is required for the demo reset worker');
+  }
+
+  let lastError;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      await mongoose.connect(process.env.MONGODB_URI);
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt < maxAttempts) {
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+      }
+    }
+  }
+  throw lastError;
+}
+
+async function main() {
+  if (!isDemoMode()) {
+    console.log('Demo reset worker disabled');
+    return;
+  }
+
+  const config = getDemoConfig();
+  await connectWithRetry();
+  await Promise.all([User.init(), Note.init(), ApiKey.init(), Settings.init()]);
+
+  while (true) {
+    const result = await resetDemoData(config);
+    console.log(`Demo data reset complete (${result.noteCount} fixture notes)`);
+    await new Promise(resolve => setTimeout(
+      resolve,
+      config.resetIntervalHours * 60 * 60 * 1000
+    ));
+  }
+}
+
+if (require.main === module) {
+  const disconnectAndExit = async () => {
+    await mongoose.disconnect().catch(() => {});
+    process.exit(0);
+  };
+  process.once('SIGTERM', disconnectAndExit);
+  process.once('SIGINT', disconnectAndExit);
+
+  main().catch(async error => {
+    console.error('Demo reset worker failed:', error.message);
+    await mongoose.disconnect().catch(() => {});
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  DEMO_NOTE_IDS,
+  buildDemoFixtures,
+  getDemoConfig,
+  inspectDemoDatabase,
+  parseResetIntervalHours,
+  resetDemoData
+};

--- a/server/server.js
+++ b/server/server.js
@@ -16,6 +16,7 @@ const errorHandler = require('./middleware/errorHandler');
 const sanitizeInputMiddleware = require('./middleware/sanitizeInput');
 const { authenticateToken } = require('./middleware/auth');
 const secureFileServe = require('./middleware/secureFileServe');
+const noStore = require('./middleware/noStore');
 const { csrfProtection, issueCsrfToken } = require('./middleware/csrfProtection');
 const passport = require('passport');
 const { configurePassport } = require('./config/passport');
@@ -116,6 +117,10 @@ app.use(helmet({
 }));
 
 app.use(compression()); // Gzip-Komprimierung für Responses
+// API and private upload responses can contain account data or session state.
+// Prevent browser, proxy, and CDN caches even when the backend is reached
+// directly instead of through the frontend proxy.
+app.use(['/api', '/uploads'], noStore);
 app.use((req, res, next) => {
   const origin = req.headers.origin;
   if (!isAllowedOrigin(req, origin)) {
@@ -127,7 +132,7 @@ app.use(express.json({ limit: '1mb' }));
 app.use(express.urlencoded({ extended: true, limit: '1mb' }));
 app.use(cookieParser());
 app.use(limiter); // Rate Limiting anwenden
-app.use(['/api/auth/login', '/api/auth/register'], authLimiter);
+app.use(['/api/auth/login', '/api/auth/register', '/api/auth/demo'], authLimiter);
 
 // Passport OAuth initialization (stateless — we use JWT, not sessions)
 app.use(passport.initialize());

--- a/server/tests/demoMode.test.js
+++ b/server/tests/demoMode.test.js
@@ -1,0 +1,249 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+const {
+  blockDemoUser,
+  createDemoNoteLimitMiddleware,
+  isDemoMode,
+  parseDemoNoteLimit,
+  rejectDemoNoteCapabilities,
+  shouldRevokeAllSessionsOnLogout
+} = require('../middleware/demoPolicy');
+const {
+  DEMO_NOTE_IDS,
+  buildDemoFixtures,
+  getDemoConfig,
+  parseResetIntervalHours
+} = require('../scripts/demoReset');
+
+function responseRecorder() {
+  return {
+    statusCode: null,
+    payload: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.payload = payload;
+      return this;
+    }
+  };
+}
+
+test('demo mode is explicit and its numeric limits are bounded', () => {
+  assert.equal(isDemoMode({ DEMO_MODE: 'true' }), true);
+  assert.equal(isDemoMode({ DEMO_MODE: 'TRUE' }), false);
+  assert.equal(isDemoMode({}), false);
+
+  assert.equal(parseDemoNoteLimit(undefined), 100);
+  assert.equal(parseDemoNoteLimit('0'), 100);
+  assert.equal(parseDemoNoteLimit('42'), 42);
+  assert.equal(parseDemoNoteLimit('9999'), 500);
+
+  assert.equal(parseResetIntervalHours(undefined), 6);
+  assert.equal(parseResetIntervalHours('12'), 12);
+  assert.equal(parseResetIntervalHours('9999'), 168);
+});
+
+test('demo-only middleware blocks high-risk features without affecting normal users', () => {
+  const blocked = responseRecorder();
+  let continued = false;
+  blockDemoUser('uploads')(
+    { user: { isDemo: true } },
+    blocked,
+    () => { continued = true; }
+  );
+  assert.equal(continued, false);
+  assert.equal(blocked.statusCode, 403);
+  assert.equal(blocked.payload.code, 'DEMO_FEATURE_DISABLED');
+  assert.equal(blocked.payload.feature, 'uploads');
+
+  const allowed = responseRecorder();
+  blockDemoUser('uploads')(
+    { user: { isDemo: false } },
+    allowed,
+    () => { continued = true; }
+  );
+  assert.equal(continued, true);
+  assert.equal(allowed.statusCode, null);
+});
+
+test('demo notes accept ordinary content but reject attached preview data', () => {
+  let continued = false;
+  rejectDemoNoteCapabilities(
+    { user: { isDemo: true }, body: { content: 'ok', linkPreviews: [] } },
+    responseRecorder(),
+    () => { continued = true; }
+  );
+  assert.equal(continued, true);
+
+  const blocked = responseRecorder();
+  rejectDemoNoteCapabilities(
+    {
+      user: { isDemo: true },
+      body: { linkPreviews: [{ url: 'https://example.com' }] }
+    },
+    blocked,
+    () => assert.fail('restricted demo note data must not continue')
+  );
+  assert.equal(blocked.statusCode, 403);
+  assert.equal(blocked.payload.feature, 'note_attachments');
+});
+
+test('demo note limit is checked per owner and returns a stable error contract', async () => {
+  const previousLimit = process.env.DEMO_NOTE_LIMIT;
+  process.env.DEMO_NOTE_LIMIT = '4';
+  let query;
+  const middleware = createDemoNoteLimitMiddleware(async value => {
+    query = value;
+    return 4;
+  });
+  const response = responseRecorder();
+
+  try {
+    await middleware(
+      { user: { _id: 'demo-user-id', isDemo: true } },
+      response,
+      () => assert.fail('a full demo account must not create another note')
+    );
+  } finally {
+    if (previousLimit === undefined) delete process.env.DEMO_NOTE_LIMIT;
+    else process.env.DEMO_NOTE_LIMIT = previousLimit;
+  }
+
+  assert.deepEqual(query, { userId: 'demo-user-id' });
+  assert.equal(response.statusCode, 429);
+  assert.equal(response.payload.code, 'DEMO_NOTE_LIMIT');
+});
+
+test('parallel demo note creates are serialized around the quota check', async () => {
+  const previousLimit = process.env.DEMO_NOTE_LIMIT;
+  process.env.DEMO_NOTE_LIMIT = '100';
+  let countCalls = 0;
+  const middleware = createDemoNoteLimitMiddleware(async () => {
+    countCalls += 1;
+    return 4;
+  });
+  const firstResponse = new EventEmitter();
+  const secondResponse = new EventEmitter();
+  let firstContinued = false;
+  let secondContinued = false;
+
+  try {
+    await middleware(
+      { user: { _id: 'demo-user-id', isDemo: true } },
+      firstResponse,
+      () => { firstContinued = true; }
+    );
+    const secondRequest = middleware(
+      { user: { _id: 'demo-user-id', isDemo: true } },
+      secondResponse,
+      () => { secondContinued = true; }
+    );
+
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(firstContinued, true);
+    assert.equal(secondContinued, false);
+    assert.equal(countCalls, 1);
+
+    firstResponse.emit('finish');
+    await secondRequest;
+    assert.equal(secondContinued, true);
+    assert.equal(countCalls, 2);
+    secondResponse.emit('finish');
+  } finally {
+    if (previousLimit === undefined) delete process.env.DEMO_NOTE_LIMIT;
+    else process.env.DEMO_NOTE_LIMIT = previousLimit;
+  }
+});
+
+test('logging out of one shared demo session does not revoke other visitors', () => {
+  assert.equal(shouldRevokeAllSessionsOnLogout({ isDemo: true }), false);
+  assert.equal(shouldRevokeAllSessionsOnLogout({ isDemo: false }), true);
+  assert.equal(shouldRevokeAllSessionsOnLogout(null), false);
+
+  const authRoutes = fs.readFileSync(path.join(root, 'routes/auth.js'), 'utf8');
+  assert.match(authRoutes, /shouldRevokeAllSessionsOnLogout\(req\.user\)/);
+  assert.match(authRoutes, /router\.post\('\/demo'/);
+  assert.match(authRoutes, /isDemo:\s*user\.isDemo === true/);
+  assert.match(authRoutes, /demo\s*\n\s*\}/);
+});
+
+test('the user model permits exactly one non-admin demo identity', () => {
+  const User = require('../models/User');
+  const demoPath = User.schema.path('isDemo');
+  const demoIndex = User.schema.indexes()
+    .find(([, options]) => options.name === 'single_demo_user');
+
+  assert.ok(demoPath);
+  assert.equal(demoPath.defaultValue, false);
+  assert.ok(demoIndex);
+  assert.equal(demoIndex[1].unique, true);
+  assert.deepEqual(demoIndex[1].partialFilterExpression, { isDemo: true });
+});
+
+test('demo reset fixtures are deterministic and exercise core note states', () => {
+  const userId = '66d000000000000000000099';
+  const now = new Date('2026-07-17T12:00:00.000Z');
+  const fixtures = buildDemoFixtures(userId, now);
+  const secondBuild = buildDemoFixtures(userId, now);
+
+  assert.equal(fixtures.length, 4);
+  assert.deepEqual(fixtures, secondBuild);
+  assert.deepEqual(fixtures.map(note => note._id.toString()), DEMO_NOTE_IDS);
+  assert.equal(fixtures.filter(note => note.isPinned).length, 1);
+  assert.equal(fixtures.filter(note => note.isTodoList).length, 1);
+  assert.equal(fixtures.filter(note => note.isArchived).length, 1);
+  assert.ok(fixtures.every(note => note.userId === userId));
+
+  const config = getDemoConfig({});
+  assert.equal(config.username, 'demo');
+  assert.equal(config.email, 'demo@keeplocal.invalid');
+  assert.equal(config.resetIntervalHours, 6);
+});
+
+test('all restricted routes and the reset worker are wired into deployment', () => {
+  const notes = fs.readFileSync(path.join(root, 'routes/notes.js'), 'utf8');
+  const apiKeys = fs.readFileSync(path.join(root, 'routes/apiKeys.js'), 'utf8');
+  const friends = fs.readFileSync(path.join(root, 'routes/friends.js'), 'utf8');
+  const server = fs.readFileSync(path.join(root, 'server.js'), 'utf8');
+  const supervisor = fs.readFileSync(path.join(root, '../supervisord.conf'), 'utf8');
+
+  assert.match(notes, /blockDemoCollaboration/);
+  assert.match(notes, /blockDemoLinkPreview/);
+  assert.match(notes, /blockDemoUploads/);
+  assert.match(notes, /blockDemoTranscription/);
+  assert.match(notes, /enforceDemoNoteLimit/);
+  assert.match(apiKeys, /router\.use\(blockDemoUser\('api_keys'\)\)/);
+  assert.match(friends, /router\.use\(blockDemoUser\('collaboration'\)\)/);
+  assert.match(server, /'\/api\/auth\/demo'/);
+  assert.match(supervisor, /\[program:demo-reset\]/);
+  assert.match(supervisor, /programs=mongodb,ai,demo-reset,nodejs,nginx/);
+  assert.doesNotMatch(supervisor, /^environment=/m);
+});
+
+test('API and upload responses are marked private and non-cacheable', () => {
+  const noStore = require('../middleware/noStore');
+  const headers = {};
+  let continued = false;
+  noStore({}, {
+    setHeader(name, value) {
+      headers[name] = value;
+    }
+  }, () => {
+    continued = true;
+  });
+
+  assert.equal(continued, true);
+  assert.equal(headers['Cache-Control'], 'private, no-store, max-age=0');
+  assert.equal(headers.Pragma, 'no-cache');
+  assert.equal(headers.Expires, '0');
+
+  const server = fs.readFileSync(path.join(root, 'server.js'), 'utf8');
+  assert.match(server, /app\.use\(\['\/api', '\/uploads'\], noStore\)/);
+});

--- a/server/tests/deploymentSecurity.test.js
+++ b/server/tests/deploymentSecurity.test.js
@@ -103,10 +103,8 @@ test('all deployment variants pass authentication security settings through', ()
   }
 
   const supervisor = fs.readFileSync(path.join(root, 'supervisord.conf'), 'utf8');
-  assert.match(supervisor, /CSRF_SECRET="%\(ENV_CSRF_SECRET\)s"/);
-  assert.match(supervisor, /COOKIE_SECURE="%\(ENV_COOKIE_SECURE\)s"/);
-  assert.match(supervisor, /GOOGLE_CLIENT_ID="%\(ENV_GOOGLE_CLIENT_ID\)s"/);
-  assert.match(supervisor, /GITHUB_CLIENT_ID="%\(ENV_GITHUB_CLIENT_ID\)s"/);
+  assert.doesNotMatch(supervisor, /^environment=/m);
+  assert.match(supervisor, /\[program:nodejs\][\s\S]*?command=\/usr\/bin\/node server\.js/);
 });
 
 test('application containers drop root privileges', () => {

--- a/server/tests/publicDemoDeployment.test.js
+++ b/server/tests/publicDemoDeployment.test.js
@@ -1,0 +1,57 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const root = path.resolve(__dirname, '../..');
+
+test('public demo compose requires an immutable image and isolated data paths', () => {
+  const compose = fs.readFileSync(path.join(root, 'docker-compose.demo.yml'), 'utf8');
+
+  assert.match(compose, /image: \$\{KEEPLOCAL_DEMO_IMAGE:\?/);
+  assert.doesNotMatch(compose, /image:\s*[^\n]*:latest/);
+  assert.doesNotMatch(compose, /^\s+ports:/m);
+  assert.match(compose, /\/mnt\/user\/appdata\/keeplocal-demo\/mongodb:\/data\/db/);
+  assert.match(compose, /\/mnt\/user\/appdata\/keeplocal-demo\/uploads:\/app\/server\/uploads/);
+  assert.doesNotMatch(compose, /\/mnt\/user\/appdata\/keeplocal\/(?:mongodb|uploads)/);
+  assert.match(compose, /MONGODB_URI: mongodb:\/\/localhost:27017\/keeplocal-demo/);
+  assert.match(compose, /brian_traefik-public:\n\s+external: true/);
+});
+
+test('public demo is private by default and Traefik exposes only API data paths', () => {
+  const compose = fs.readFileSync(path.join(root, 'docker-compose.demo.yml'), 'utf8');
+  const rule = compose.match(/traefik\.http\.routers\.keeplocal-demo\.rule: ([^\n]+)/)?.[1] || '';
+
+  assert.match(compose, /traefik\.enable: \$\{TRAEFIK_ENABLE:-false\}/);
+  assert.match(rule, /Host\(`keeplocal-demo\.zwaetschge-webui\.ch`\)/);
+  assert.match(rule, /Path\(`\/api`\)/);
+  assert.match(rule, /PathPrefix\(`\/api\/`\)/);
+  assert.match(rule, /Path\(`\/uploads`\)/);
+  assert.match(rule, /PathPrefix\(`\/uploads\/`\)/);
+  assert.doesNotMatch(rule, /PathPrefix\(`\/`\)/);
+  assert.match(compose, /tls\.certresolver: cloudflare/);
+  assert.match(compose, /middlewares: security-headers@file/);
+  assert.match(compose, /loadbalancer\.server\.port: "80"/);
+});
+
+test('public demo compose enables the sandbox without embedding credentials', () => {
+  const compose = fs.readFileSync(path.join(root, 'docker-compose.demo.yml'), 'utf8');
+  const dockerfile = fs.readFileSync(path.join(root, 'Dockerfile.allinone'), 'utf8');
+  const runtimeEnvironment = dockerfile.match(/# Environment variables with defaults\nENV ([\s\S]*?)\n\n# Health check/)?.[1] || '';
+
+  assert.match(compose, /JWT_SECRET: \$\{JWT_SECRET:\?/);
+  assert.match(compose, /CSRF_SECRET: \$\{CSRF_SECRET:\?/);
+  assert.match(compose, /COOKIE_SECURE: "true"/);
+  assert.match(compose, /ALLOWED_ORIGINS: https:\/\/keep-local-silk\.vercel\.app/);
+  assert.match(compose, /CLIENT_URL: https:\/\/keep-local-silk\.vercel\.app/);
+  assert.match(compose, /DEMO_MODE: "true"/);
+  assert.match(compose, /DEMO_RESET_INTERVAL_HOURS: \$\{DEMO_RESET_INTERVAL_HOURS:-6\}/);
+  assert.match(compose, /DEMO_NOTE_LIMIT: \$\{DEMO_NOTE_LIMIT:-100\}/);
+
+  assert.match(runtimeEnvironment, /DEMO_MODE=false/);
+  assert.match(runtimeEnvironment, /DEMO_RESET_INTERVAL_HOURS=6/);
+  assert.match(runtimeEnvironment, /DEMO_NOTE_LIMIT=100/);
+  assert.doesNotMatch(runtimeEnvironment, /CSRF_SECRET=/);
+  assert.doesNotMatch(runtimeEnvironment, /GOOGLE_CLIENT_SECRET=/);
+  assert.doesNotMatch(runtimeEnvironment, /GITHUB_CLIENT_SECRET=/);
+});

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -32,7 +32,23 @@ stdout_logfile=/var/log/supervisor/ai-stdout.log
 stderr_logfile=/var/log/supervisor/ai-stderr.log
 priority=2
 user=node
-environment=WHISPER_MODEL="%(ENV_WHISPER_MODEL)s",HF_HOME="%(ENV_HF_HOME)s"
+
+# Periodically restore the deliberately isolated public demo account. The
+# worker exits cleanly when DEMO_MODE is not enabled.
+[program:demo-reset]
+command=/usr/bin/node scripts/demoReset.js
+directory=/app/server
+autostart=true
+autorestart=unexpected
+exitcodes=0
+startretries=10
+startsecs=0
+stdout_logfile=/var/log/supervisor/demo-reset-stdout.log
+stderr_logfile=/var/log/supervisor/demo-reset-stderr.log
+priority=2
+user=node
+stopasgroup=true
+killasgroup=true
 
 # Node.js Backend Service
 [program:nodejs]
@@ -46,7 +62,6 @@ stdout_logfile=/var/log/supervisor/nodejs-stdout.log
 stderr_logfile=/var/log/supervisor/nodejs-stderr.log
 priority=3
 user=node
-environment=NODE_ENV="%(ENV_NODE_ENV)s",PORT="%(ENV_PORT)s",HOST="%(ENV_HOST)s",TRUST_PROXY="%(ENV_TRUST_PROXY)s",MONGODB_URI="%(ENV_MONGODB_URI)s",JWT_SECRET="%(ENV_JWT_SECRET)s",JWT_EXPIRES_IN="%(ENV_JWT_EXPIRES_IN)s",CSRF_SECRET="%(ENV_CSRF_SECRET)s",COOKIE_SECURE="%(ENV_COOKIE_SECURE)s",ALLOWED_ORIGINS="%(ENV_ALLOWED_ORIGINS)s",AI_SERVICE_URL="%(ENV_AI_SERVICE_URL)s",CLIENT_URL="%(ENV_CLIENT_URL)s",GOOGLE_CLIENT_ID="%(ENV_GOOGLE_CLIENT_ID)s",GOOGLE_CLIENT_SECRET="%(ENV_GOOGLE_CLIENT_SECRET)s",GOOGLE_CALLBACK_URL="%(ENV_GOOGLE_CALLBACK_URL)s",GITHUB_CLIENT_ID="%(ENV_GITHUB_CLIENT_ID)s",GITHUB_CLIENT_SECRET="%(ENV_GITHUB_CLIENT_SECRET)s",GITHUB_CALLBACK_URL="%(ENV_GITHUB_CALLBACK_URL)s"
 
 # Nginx Service
 [program:nginx]
@@ -61,5 +76,5 @@ priority=4
 
 # Group all services together
 [group:keeplocal]
-programs=mongodb,ai,nodejs,nginx
+programs=mongodb,ai,demo-reset,nodejs,nginx
 priority=999


### PR DESCRIPTION
## What changed

- adds a passwordless, explicitly gated public demo session
- seeds four representative notes and resets the shared sandbox every six hours
- blocks uploads, transcription, link previews, API keys, friends, and sharing for demo users
- adds a 100-note quota and private/no-store API responses
- connects the Vercel client to an isolated backend through same-origin rewrites
- adds a dedicated, Traefik-disabled-by-default demo Compose contract with separate data paths
- documents the public demo, rollout, isolation, and rollback

## Verification

- server: 55/55 tests
- client: 30/30 tests, ESLint, Vite production build
- AI: 4/4 tests
- Compose render and whitespace checks
- live isolated staging: demo login, seeded notes, CRUD, blocked capabilities, CORS, CSRF, and independent logout sessions

## Rollout

The demo stack must use the newly published immutable multi-architecture image digest. It starts with `TRAEFIK_ENABLE=false`; only after private health/seeding checks should the `/api` and `/uploads` router be enabled. Existing KeepLocal data and the current production container are not reused.