### PR TITLE
Prevent startup crash when browser storage is blocked

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -22,6 +22,9 @@ import { LanguageProvider, useLanguage } from './contexts/LanguageContext';
 import { SettingsProvider } from './contexts/SettingsContext';
 import { initializeCSRF, notesAPI } from './services/api';
 import { useKeyboardShortcuts } from './hooks';
+import { readLocalStorage, writeLocalStorage } from './utils/localStorage.mjs';
+
+const THEMES = new Set(['light', 'dark', 'oled', 'eink', 'doodle']);
 
 function AppContent() {
   const { user, isLoggedIn, loading: authLoading, setupNeeded, login, demoLogin, register, logout, setup, completeOAuthLogin } = useAuth();
@@ -39,8 +42,8 @@ function AppContent() {
   const [allTags, setAllTags] = useState([]);
   const [operationLoading, setOperationLoading] = useState({});
   const [theme, setTheme] = useState(() => {
-    const savedTheme = localStorage.getItem('theme');
-    return savedTheme || 'light'; // 'light', 'dark', 'oled', 'eink', or 'doodle'
+    const savedTheme = readLocalStorage('theme');
+    return THEMES.has(savedTheme) ? savedTheme : 'light';
   });
   const [draggedNoteId, setDraggedNoteId] = useState(null);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
@@ -80,7 +83,7 @@ function AppContent() {
       document.body.classList.add('doodle-mode');
     }
 
-    localStorage.setItem('theme', theme);
+    writeLocalStorage('theme', theme);
   }, [theme]);
 
   // Notizen vom Server laden

--- a/client/src/contexts/AuthContext.jsx
+++ b/client/src/contexts/AuthContext.jsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import { authAPI, initializeCSRF } from '../services/api';
+import { removeLocalStorage } from '../utils/localStorage.mjs';
 
 const AuthContext = createContext();
 
@@ -19,7 +20,7 @@ export function AuthProvider({ children }) {
 
   // Check if user is authenticated and setup status on mount
   useEffect(() => {
-    window.localStorage.removeItem('token');
+    removeLocalStorage('token');
 
     const checkAuth = async () => {
       // First check if initial setup is needed

--- a/client/src/contexts/SettingsContext.jsx
+++ b/client/src/contexts/SettingsContext.jsx
@@ -5,6 +5,7 @@
  */
 
 import React, { createContext, useContext, useState, useEffect } from 'react';
+import { readLocalStorage, writeLocalStorage } from '../utils/localStorage.mjs';
 
 const SettingsContext = createContext();
 
@@ -18,7 +19,7 @@ const DEFAULT_SETTINGS = {
 export function SettingsProvider({ children }) {
   const [settings, setSettings] = useState(() => {
     // Load from localStorage or use defaults
-    const savedSettings = localStorage.getItem('keeplocal_settings');
+    const savedSettings = readLocalStorage('keeplocal_settings');
     if (savedSettings) {
       try {
         return { ...DEFAULT_SETTINGS, ...JSON.parse(savedSettings) };
@@ -32,11 +33,7 @@ export function SettingsProvider({ children }) {
 
   // Save to localStorage whenever settings change
   useEffect(() => {
-    try {
-      localStorage.setItem('keeplocal_settings', JSON.stringify(settings));
-    } catch (error) {
-      console.error('Error saving settings to localStorage:', error);
-    }
+    writeLocalStorage('keeplocal_settings', JSON.stringify(settings));
   }, [settings]);
 
   const updateSettings = (newSettings) => {

--- a/client/src/utils/localStorage.mjs
+++ b/client/src/utils/localStorage.mjs
@@ -1,0 +1,40 @@
+function resolveLocalStorage() {
+  try {
+    return globalThis.localStorage || null;
+  } catch {
+    return null;
+  }
+}
+
+export function readLocalStorage(key, fallback = null, storage = resolveLocalStorage()) {
+  if (!storage) return fallback;
+
+  try {
+    const value = storage.getItem(key);
+    return value == null ? fallback : value;
+  } catch {
+    return fallback;
+  }
+}
+
+export function writeLocalStorage(key, value, storage = resolveLocalStorage()) {
+  if (!storage) return false;
+
+  try {
+    storage.setItem(key, value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function removeLocalStorage(key, storage = resolveLocalStorage()) {
+  if (!storage) return false;
+
+  try {
+    storage.removeItem(key);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/client/tests/localStorageFallback.test.js
+++ b/client/tests/localStorageFallback.test.js
@@ -1,0 +1,61 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const test = require('node:test');
+const { pathToFileURL } = require('node:url');
+
+const moduleUrl = pathToFileURL(
+  path.resolve(__dirname, '../src/utils/localStorage.mjs'),
+).href;
+
+test('local storage helpers preserve values when storage is available', async () => {
+  const { readLocalStorage, removeLocalStorage, writeLocalStorage } = await import(moduleUrl);
+  const values = new Map();
+  const storage = {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, String(value)),
+    removeItem: (key) => values.delete(key),
+  };
+
+  assert.equal(readLocalStorage('theme', 'light', storage), 'light');
+  assert.equal(writeLocalStorage('theme', 'doodle', storage), true);
+  assert.equal(readLocalStorage('theme', 'light', storage), 'doodle');
+  assert.equal(removeLocalStorage('theme', storage), true);
+  assert.equal(readLocalStorage('theme', 'light', storage), 'light');
+});
+
+test('local storage helpers fail safely when browser storage methods throw', async () => {
+  const { readLocalStorage, removeLocalStorage, writeLocalStorage } = await import(moduleUrl);
+  const blockedStorage = {
+    getItem: () => { throw new DOMException('blocked', 'SecurityError'); },
+    setItem: () => { throw new DOMException('blocked', 'SecurityError'); },
+    removeItem: () => { throw new DOMException('blocked', 'SecurityError'); },
+  };
+
+  assert.equal(readLocalStorage('theme', 'light', blockedStorage), 'light');
+  assert.equal(writeLocalStorage('theme', 'dark', blockedStorage), false);
+  assert.equal(removeLocalStorage('token', blockedStorage), false);
+});
+
+test('local storage helpers fail safely when the browser blocks the storage getter', async () => {
+  const { readLocalStorage, removeLocalStorage, writeLocalStorage } = await import(moduleUrl);
+  const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    get() {
+      throw new DOMException('blocked', 'SecurityError');
+    },
+  });
+
+  try {
+    assert.equal(readLocalStorage('theme', 'light'), 'light');
+    assert.equal(writeLocalStorage('theme', 'dark'), false);
+    assert.equal(removeLocalStorage('token'), false);
+  } finally {
+    if (originalDescriptor) {
+      Object.defineProperty(globalThis, 'localStorage', originalDescriptor);
+    } else {
+      delete globalThis.localStorage;
+    }
+  }
+});

--- a/client/tests/themeModes.test.js
+++ b/client/tests/themeModes.test.js
@@ -12,7 +12,8 @@ function readClientFile(...parts) {
 test('theme cycle includes doodle mode after e-ink and applies the body class', () => {
   const app = readClientFile('src/App.jsx');
 
-  assert.match(app, /savedTheme \|\| 'light'; \/\/ 'light', 'dark', 'oled', 'eink', or 'doodle'/);
+  assert.match(app, /readLocalStorage\('theme'\)/);
+  assert.match(app, /THEMES\.has\(savedTheme\) \? savedTheme : 'light'/);
   assert.match(app, /classList\.remove\('dark-mode', 'oled-mode', 'eink-mode', 'doodle-mode'\)/);
   assert.match(app, /theme === 'doodle'/);
   assert.match(app, /classList\.add\('doodle-mode'\)/);


### PR DESCRIPTION
## Root cause

Direct `localStorage` reads and writes during React startup throw a `SecurityError` when browser storage is disabled or unavailable. That error was reproduced against the public production build and produced the exact generic ErrorBoundary screen.

## Fix

- route theme, legacy-token cleanup, and settings persistence through a fail-safe storage adapter
- fall back to the light theme and default settings when storage is unavailable
- reject unknown persisted theme values
- add deterministic tests for blocked storage methods and a throwing storage getter

## Verification

- client tests: 33/33
- server tests: 55/55
- ESLint
- Vite production build
- Chromium desktop 1440×900 and mobile 390×844 with `localStorage` forced to throw before every access; initial render and reload both succeed without ErrorBoundary or overflow