### PR TITLE
Prevent privacy-browser startup crashes and repair stale PWA state

### DIFF
--- a/client/public/service-worker.js
+++ b/client/public/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'keeplocal-v4';
+const CACHE_NAME = 'keeplocal-v5';
 const urlsToCache = [
   '/',
   '/index.html',
@@ -36,7 +36,9 @@ self.addEventListener('install', event => {
 self.addEventListener('activate', event => {
   const cleanup = caches.keys().then(cacheNames => Promise.all(
     cacheNames.map(cacheName => (
-      cacheName === CACHE_NAME ? null : caches.delete(cacheName)
+      cacheName.startsWith('keeplocal-') && cacheName !== CACHE_NAME
+        ? caches.delete(cacheName)
+        : null
     ))
   ));
   event.waitUntil(Promise.all([cleanup, self.clients.claim()]));

--- a/client/src/components/ErrorBoundary.css
+++ b/client/src/components/ErrorBoundary.css
@@ -3,124 +3,179 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  padding: 20px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  padding: var(--space-5);
+  font-family: var(--font-body);
 }
 
 .error-boundary-content {
-  background: white;
-  border-radius: 12px;
-  padding: 40px;
+  position: relative;
+  background: var(--bg-elevated);
+  border: 2px solid var(--border-color-strong);
+  border-radius: var(--radius-lg) var(--radius-xl) var(--radius-md) var(--radius-xl);
+  padding: var(--space-10);
   max-width: 600px;
   width: 100%;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  box-shadow: 7px 8px 0 var(--border-color);
   text-align: center;
 }
 
 .error-boundary h1 {
-  margin: 0 0 20px 0;
-  color: #333;
-  font-size: 2em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  margin: 0 0 var(--space-5);
+  color: var(--text-primary);
+  font-family: var(--font-display);
+  font-size: var(--font-size-3xl);
+  line-height: var(--leading-tight);
+}
+
+.error-boundary-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+  border: 2px solid currentColor;
+  border-radius: 48% 55% 46% 52%;
+  font-family: var(--font-body);
+  font-size: var(--font-size-xl);
+  transform: rotate(-3deg);
 }
 
 .error-boundary-message {
-  color: #666;
-  font-size: 1.1em;
-  margin-bottom: 30px;
-  line-height: 1.6;
+  color: var(--text-secondary);
+  font-size: var(--font-size-lg);
+  margin-bottom: var(--space-6);
+  line-height: var(--leading-relaxed);
+}
+
+.error-boundary-diagnostic {
+  display: inline-block;
+  margin: 0 0 var(--space-5);
+  padding: var(--space-2) var(--space-3);
+  border: 1px dashed var(--border-color-strong);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+  font-size: var(--font-size-sm);
+}
+
+.error-boundary-diagnostic code {
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-weight: var(--font-semibold);
 }
 
 .error-boundary-details {
   text-align: left;
-  margin: 20px 0;
-  background: #f5f5f5;
-  border-radius: 8px;
-  padding: 15px;
+  margin: var(--space-5) 0;
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
 }
 
 .error-boundary-details summary {
   cursor: pointer;
   font-weight: 600;
-  color: #667eea;
-  margin-bottom: 10px;
+  color: var(--accent-color);
+  margin-bottom: var(--space-3);
   user-select: none;
 }
 
 .error-boundary-details summary:hover {
-  color: #764ba2;
+  color: var(--accent-hover);
 }
 
 .error-boundary-stack {
   background: #2d2d2d;
   color: #f8f8f2;
   padding: 15px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   overflow-x: auto;
   font-family: 'Courier New', monospace;
   font-size: 0.85em;
   line-height: 1.5;
-  margin-top: 10px;
+  margin-top: var(--space-3);
 }
 
 .error-boundary-actions {
   display: flex;
-  gap: 15px;
+  gap: var(--space-3);
   justify-content: center;
-  margin: 30px 0;
+  margin: var(--space-6) 0;
 }
 
 .error-boundary-button {
-  padding: 12px 30px;
-  font-size: 1em;
-  font-weight: 600;
-  border: none;
-  border-radius: 8px;
+  min-height: 46px;
+  padding: var(--space-3) var(--space-6);
+  font: inherit;
+  font-weight: var(--font-semibold);
+  border: 2px solid var(--accent-active);
+  border-radius: var(--radius-md) var(--radius-lg) var(--radius-md) var(--radius-lg);
   cursor: pointer;
-  transition: all 0.2s ease;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
+  transition: transform var(--duration-fast) var(--ease-out), box-shadow var(--duration-fast) var(--ease-out);
+  background: var(--accent-color);
+  color: var(--text-inverse);
 }
 
 .error-boundary-button:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 5px 15px rgba(102, 126, 234, 0.4);
+  transform: translateY(-1px) rotate(-0.2deg);
+  box-shadow: 3px 4px 0 var(--border-color-strong);
+}
+
+.error-boundary-button:focus-visible {
+  outline: 3px solid var(--border-focus);
+  outline-offset: 3px;
+}
+
+.error-boundary-button:disabled {
+  cursor: wait;
+  opacity: 0.72;
+  transform: none;
+  box-shadow: none;
 }
 
 .error-boundary-button-secondary {
-  background: #f5f5f5;
-  color: #333;
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  border-color: var(--border-color-strong);
 }
 
 .error-boundary-button-secondary:hover {
-  background: #e0e0e0;
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
+  background: var(--bg-tertiary);
+  box-shadow: 3px 4px 0 var(--border-color);
 }
 
 .error-boundary-help {
-  margin: 30px 0 10px 0;
-  color: #666;
-  font-weight: 600;
+  margin: var(--space-5) auto 0;
+  max-width: 450px;
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: var(--leading-relaxed);
 }
 
-.error-boundary-suggestions {
-  text-align: left;
-  color: #666;
-  line-height: 1.8;
-  margin: 0 auto;
-  max-width: 400px;
+.error-boundary-status {
+  margin: calc(var(--space-3) * -1) auto var(--space-4);
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
 }
 
-.error-boundary-suggestions li {
-  margin-bottom: 8px;
+.error-boundary-status-error {
+  color: var(--error-color);
 }
 
 @media (max-width: 600px) {
   .error-boundary-content {
-    padding: 30px 20px;
+    padding: var(--space-8) var(--space-5);
   }
 
   .error-boundary h1 {
-    font-size: 1.5em;
+    font-size: var(--font-size-2xl);
   }
 
   .error-boundary-actions {
@@ -132,31 +187,12 @@
   }
 }
 
-/* Dark mode support */
-body.dark-mode .error-boundary-content {
-  background: #2d2d2d;
-  color: #e4e4e4;
-}
+@media (prefers-reduced-motion: reduce) {
+  .error-boundary-button {
+    transition: none;
+  }
 
-body.dark-mode .error-boundary h1 {
-  color: #e4e4e4;
-}
-
-body.dark-mode .error-boundary-message,
-body.dark-mode .error-boundary-help,
-body.dark-mode .error-boundary-suggestions {
-  color: #b0b0b0;
-}
-
-body.dark-mode .error-boundary-details {
-  background: #1a1a1a;
-}
-
-body.dark-mode .error-boundary-button-secondary {
-  background: #3a3a3a;
-  color: #e4e4e4;
-}
-
-body.dark-mode .error-boundary-button-secondary:hover {
-  background: #4a4a4a;
+  .error-boundary-button:hover {
+    transform: none;
+  }
 }

--- a/client/src/components/ErrorBoundary.jsx
+++ b/client/src/components/ErrorBoundary.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import './ErrorBoundary.css';
+import { repairAppCaches } from '../utils/appRecovery.mjs';
+import { buildErrorDiagnostic } from '../utils/errorDiagnostic.mjs';
 
 class ErrorBoundary extends React.Component {
   constructor(props) {
@@ -7,7 +9,10 @@ class ErrorBoundary extends React.Component {
     this.state = {
       hasError: false,
       error: null,
-      errorInfo: null
+      errorInfo: null,
+      diagnostic: null,
+      isRepairing: false,
+      repairFailed: false
     };
   }
 
@@ -17,14 +22,12 @@ class ErrorBoundary extends React.Component {
   }
 
   componentDidCatch(error, errorInfo) {
-    // Log error to console in development
-    if (import.meta.env.DEV) {
-      console.error('ErrorBoundary caught an error:', error, errorInfo);
-    }
+    console.error('ErrorBoundary caught an error:', error, errorInfo);
 
     this.setState({
       error,
-      errorInfo
+      errorInfo,
+      diagnostic: buildErrorDiagnostic(error, errorInfo)
     });
 
     // Here you could also log to an error reporting service
@@ -35,11 +38,30 @@ class ErrorBoundary extends React.Component {
     this.setState({
       hasError: false,
       error: null,
-      errorInfo: null
+      errorInfo: null,
+      diagnostic: null,
+      isRepairing: false,
+      repairFailed: false
     });
 
     // Reload the page to reset the app
     window.location.reload();
+  };
+
+  handleRepair = async () => {
+    if (this.state.isRepairing) return;
+
+    this.setState({ isRepairing: true, repairFailed: false });
+
+    try {
+      await repairAppCaches();
+      const url = new URL(window.location.href);
+      url.searchParams.set('app-repair', Date.now().toString(36));
+      window.location.replace(url.toString());
+    } catch (error) {
+      console.error('App recovery failed:', error);
+      this.setState({ isRepairing: false, repairFailed: true });
+    }
   };
 
   render() {
@@ -47,10 +69,20 @@ class ErrorBoundary extends React.Component {
       return (
         <div className="error-boundary">
           <div className="error-boundary-content">
-            <h1>😔 Etwas ist schiefgelaufen</h1>
+            <h1>
+              <span className="error-boundary-mark" aria-hidden="true">!</span>
+              Etwas ist schiefgelaufen
+            </h1>
             <p className="error-boundary-message">
               Die Anwendung ist auf einen unerwarteten Fehler gestoßen.
             </p>
+
+            {this.state.diagnostic && (
+              <p className="error-boundary-diagnostic">
+                Diagnose: <code>{this.state.diagnostic.code}</code>
+                {' · '}{this.state.diagnostic.name}
+              </p>
+            )}
 
             {import.meta.env.DEV && this.state.error && (
               <details className="error-boundary-details">
@@ -69,25 +101,35 @@ class ErrorBoundary extends React.Component {
             )}
 
             <div className="error-boundary-actions">
-              <button onClick={this.handleReset} className="error-boundary-button">
-                Anwendung neu laden
+              <button
+                onClick={this.handleRepair}
+                className="error-boundary-button"
+                disabled={this.state.isRepairing}
+              >
+                {this.state.isRepairing ? 'App wird aktualisiert …' : 'App sicher aktualisieren'}
               </button>
               <button
-                onClick={() => window.history.back()}
+                onClick={this.handleReset}
                 className="error-boundary-button error-boundary-button-secondary"
               >
-                Zurück
+                Nur neu laden
               </button>
             </div>
 
+            {this.state.isRepairing && (
+              <p className="error-boundary-status" role="status">
+                Alte App-Dateien werden entfernt und frisch geladen.
+              </p>
+            )}
+            {this.state.repairFailed && (
+              <p className="error-boundary-status error-boundary-status-error" role="alert">
+                Die automatische Aktualisierung wurde blockiert. Bitte laden Sie die Seite neu.
+              </p>
+            )}
+
             <p className="error-boundary-help">
-              Wenn das Problem weiterhin besteht, versuchen Sie:
+              „App sicher aktualisieren“ erneuert nur die Web-App. Konto und Notizen bleiben erhalten.
             </p>
-            <ul className="error-boundary-suggestions">
-              <li>Browser-Cache leeren</li>
-              <li>Auf einem anderen Browser versuchen</li>
-              <li>Den Support kontaktieren</li>
-            </ul>
           </div>
         </div>
       );

--- a/client/src/contexts/LanguageContext.jsx
+++ b/client/src/contexts/LanguageContext.jsx
@@ -1,23 +1,18 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { translations, defaultLanguage } from '../translations';
+import { getBrowserLanguage } from '../utils/browserLanguage.mjs';
 
 const LanguageContext = createContext();
 
-function getBrowserLanguage() {
-  const browserLang = navigator.language.split('-')[0];
-  if (translations[browserLang]) {
-    return browserLang;
-  }
-  return defaultLanguage;
-}
+const resolveLanguage = () => getBrowserLanguage(translations, defaultLanguage);
 
 export function LanguageProvider({ children }) {
-  const [language, setLanguage] = useState(getBrowserLanguage);
+  const [language, setLanguage] = useState(resolveLanguage);
 
   // Listen for browser language changes
   useEffect(() => {
     function handleLanguageChange() {
-      setLanguage(getBrowserLanguage());
+      setLanguage(resolveLanguage());
     }
 
     window.addEventListener('languagechange', handleLanguageChange);

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -20,9 +20,15 @@ root.render(
 );
 
 if ('serviceWorker' in navigator && import.meta.env.PROD) {
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/service-worker.js').catch(error => {
+  window.addEventListener('load', async () => {
+    try {
+      const registration = await navigator.serviceWorker.register(
+        '/service-worker.js',
+        { updateViaCache: 'none' }
+      );
+      await registration.update();
+    } catch (error) {
       console.error('Service worker registration failed:', error);
-    });
-  });
+    }
+  }, { once: true });
 }

--- a/client/src/utils/appRecovery.mjs
+++ b/client/src/utils/appRecovery.mjs
@@ -1,0 +1,79 @@
+export const APP_CACHE_PREFIX = 'keeplocal-';
+
+async function unregisterServiceWorkers(environment) {
+  let serviceWorker;
+
+  try {
+    serviceWorker = environment?.navigator?.serviceWorker;
+  } catch {
+    return 0;
+  }
+
+  if (!serviceWorker || typeof serviceWorker.getRegistrations !== 'function') {
+    return 0;
+  }
+
+  try {
+    const registrations = await serviceWorker.getRegistrations();
+    const results = await Promise.all(
+      Array.from(registrations).map(async registration => {
+        try {
+          return await registration.unregister();
+        } catch {
+          return false;
+        }
+      })
+    );
+
+    return results.filter(Boolean).length;
+  } catch {
+    return 0;
+  }
+}
+
+async function removeAppCaches(environment) {
+  let cacheStorage;
+
+  try {
+    cacheStorage = environment?.caches;
+  } catch {
+    return 0;
+  }
+
+  if (
+    !cacheStorage ||
+    typeof cacheStorage.keys !== 'function' ||
+    typeof cacheStorage.delete !== 'function'
+  ) {
+    return 0;
+  }
+
+  try {
+    const cacheNames = await cacheStorage.keys();
+    const appCacheNames = cacheNames.filter(cacheName => (
+      typeof cacheName === 'string' && cacheName.startsWith(APP_CACHE_PREFIX)
+    ));
+    const results = await Promise.all(
+      appCacheNames.map(async cacheName => {
+        try {
+          return await cacheStorage.delete(cacheName);
+        } catch {
+          return false;
+        }
+      })
+    );
+
+    return results.filter(Boolean).length;
+  } catch {
+    return 0;
+  }
+}
+
+export async function repairAppCaches(environment = globalThis) {
+  const [unregisteredWorkers, removedCaches] = await Promise.all([
+    unregisterServiceWorkers(environment),
+    removeAppCaches(environment)
+  ]);
+
+  return { unregisteredWorkers, removedCaches };
+}

--- a/client/src/utils/browserLanguage.mjs
+++ b/client/src/utils/browserLanguage.mjs
@@ -1,0 +1,43 @@
+export function resolveBrowserLanguage(
+  navigatorObject,
+  supportedLanguages,
+  fallbackLanguage
+) {
+  let rawLanguage;
+
+  try {
+    rawLanguage = navigatorObject?.language;
+  } catch {
+    return fallbackLanguage;
+  }
+
+  if (typeof rawLanguage !== 'string') {
+    return fallbackLanguage;
+  }
+
+  const browserLanguage = rawLanguage.trim().split(/[-_]/)[0].toLowerCase();
+  if (
+    browserLanguage &&
+    Object.prototype.hasOwnProperty.call(supportedLanguages, browserLanguage)
+  ) {
+    return browserLanguage;
+  }
+
+  return fallbackLanguage;
+}
+
+export function getBrowserLanguage(supportedLanguages, fallbackLanguage) {
+  let navigatorObject;
+
+  try {
+    navigatorObject = globalThis.navigator;
+  } catch {
+    return fallbackLanguage;
+  }
+
+  return resolveBrowserLanguage(
+    navigatorObject,
+    supportedLanguages,
+    fallbackLanguage
+  );
+}

--- a/client/src/utils/errorDiagnostic.mjs
+++ b/client/src/utils/errorDiagnostic.mjs
@@ -1,0 +1,27 @@
+function safeErrorValue(readValue, fallback = '') {
+  try {
+    return String(readValue() ?? fallback);
+  } catch {
+    return fallback;
+  }
+}
+
+export function buildErrorDiagnostic(error, errorInfo) {
+  const name = safeErrorValue(() => error?.name, 'Error')
+    .replace(/[^a-z0-9_.-]/gi, '')
+    .slice(0, 40) || 'Error';
+  const message = safeErrorValue(() => error?.message || error);
+  const componentStack = safeErrorValue(() => errorInfo?.componentStack);
+  const fingerprint = `${name}|${message}|${componentStack}`;
+  let hash = 2166136261;
+
+  for (let index = 0; index < fingerprint.length; index += 1) {
+    hash ^= fingerprint.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return {
+    code: `KL-${(hash >>> 0).toString(16).padStart(8, '0').toUpperCase()}`,
+    name
+  };
+}

--- a/client/tests/appRecovery.test.js
+++ b/client/tests/appRecovery.test.js
@@ -1,0 +1,65 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const test = require('node:test');
+const { pathToFileURL } = require('node:url');
+
+const moduleUrl = pathToFileURL(
+  path.join(__dirname, '../src/utils/appRecovery.mjs')
+).href;
+
+test('app recovery unregisters workers and removes only KeepLocal caches', async () => {
+  const { repairAppCaches } = await import(moduleUrl);
+  const calls = [];
+  const environment = {
+    navigator: {
+      serviceWorker: {
+        async getRegistrations() {
+          return [
+            { async unregister() { calls.push('worker-1'); return true; } },
+            { async unregister() { calls.push('worker-2'); return false; } }
+          ];
+        }
+      }
+    },
+    caches: {
+      async keys() {
+        return ['keeplocal-v4', 'keeplocal-v5', 'another-app'];
+      },
+      async delete(cacheName) {
+        calls.push(cacheName);
+        return true;
+      }
+    }
+  };
+
+  const result = await repairAppCaches(environment);
+
+  assert.deepEqual(result, { unregisteredWorkers: 1, removedCaches: 2 });
+  assert.deepEqual(
+    calls.sort(),
+    ['keeplocal-v4', 'keeplocal-v5', 'worker-1', 'worker-2'].sort()
+  );
+});
+
+test('app recovery remains usable when browser APIs are blocked', async () => {
+  const { repairAppCaches } = await import(moduleUrl);
+  const environment = {};
+
+  Object.defineProperty(environment, 'navigator', {
+    get() {
+      throw new DOMException('Blocked', 'SecurityError');
+    }
+  });
+  Object.defineProperty(environment, 'caches', {
+    get() {
+      throw new DOMException('Blocked', 'SecurityError');
+    }
+  });
+
+  await assert.doesNotReject(async () => {
+    assert.deepEqual(
+      await repairAppCaches(environment),
+      { unregisteredWorkers: 0, removedCaches: 0 }
+    );
+  });
+});

--- a/client/tests/browserLanguage.test.js
+++ b/client/tests/browserLanguage.test.js
@@ -1,0 +1,40 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const test = require('node:test');
+const { pathToFileURL } = require('node:url');
+
+const moduleUrl = pathToFileURL(
+  path.join(__dirname, '../src/utils/browserLanguage.mjs')
+).href;
+
+test('browser language resolves a supported locale', async () => {
+  const { resolveBrowserLanguage } = await import(moduleUrl);
+
+  assert.equal(
+    resolveBrowserLanguage({ language: 'EN-us' }, { de: {}, en: {} }, 'de'),
+    'en'
+  );
+});
+
+test('browser language falls back when language access is blocked', async () => {
+  const { resolveBrowserLanguage } = await import(moduleUrl);
+  const navigatorObject = {};
+  Object.defineProperty(navigatorObject, 'language', {
+    get() {
+      throw new DOMException('Language access blocked', 'SecurityError');
+    }
+  });
+
+  assert.equal(
+    resolveBrowserLanguage(navigatorObject, { de: {}, en: {} }, 'de'),
+    'de'
+  );
+});
+
+test('browser language falls back for missing and unsupported values', async () => {
+  const { resolveBrowserLanguage } = await import(moduleUrl);
+  const languages = { de: {}, en: {} };
+
+  assert.equal(resolveBrowserLanguage({}, languages, 'de'), 'de');
+  assert.equal(resolveBrowserLanguage({ language: 'fr-FR' }, languages, 'de'), 'de');
+});

--- a/client/tests/errorBoundaryRecovery.test.js
+++ b/client/tests/errorBoundaryRecovery.test.js
@@ -1,0 +1,21 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const component = fs.readFileSync(
+  path.join(__dirname, '../src/components/ErrorBoundary.jsx'),
+  'utf8'
+);
+const styles = fs.readFileSync(
+  path.join(__dirname, '../src/components/ErrorBoundary.css'),
+  'utf8'
+);
+
+test('error boundary offers safe cache recovery and a non-sensitive diagnostic', () => {
+  assert.match(component, /repairAppCaches/);
+  assert.match(component, /App sicher aktualisieren/);
+  assert.match(component, /diagnostic\.code/);
+  assert.doesNotMatch(component, /Browser-Cache leeren/);
+  assert.match(styles, /\.error-boundary-button:focus-visible/);
+});

--- a/client/tests/errorDiagnostic.test.js
+++ b/client/tests/errorDiagnostic.test.js
@@ -1,0 +1,22 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const test = require('node:test');
+const { pathToFileURL } = require('node:url');
+
+const moduleUrl = pathToFileURL(
+  path.join(__dirname, '../src/utils/errorDiagnostic.mjs')
+).href;
+
+test('error diagnostics are stable and do not expose the error message', async () => {
+  const { buildErrorDiagnostic } = await import(moduleUrl);
+  const error = new DOMException('private page details', 'SecurityError');
+  const errorInfo = { componentStack: '\n    at LanguageProvider' };
+
+  const first = buildErrorDiagnostic(error, errorInfo);
+  const second = buildErrorDiagnostic(error, errorInfo);
+
+  assert.deepEqual(first, second);
+  assert.match(first.code, /^KL-[0-9A-F]{8}$/);
+  assert.equal(first.name, 'SecurityError');
+  assert.doesNotMatch(JSON.stringify(first), /private page details/);
+});

--- a/client/tests/serviceWorkerCacheStrategy.test.js
+++ b/client/tests/serviceWorkerCacheStrategy.test.js
@@ -7,6 +7,10 @@ const serviceWorker = fs.readFileSync(
   path.join(__dirname, '../public/service-worker.js'),
   'utf8'
 );
+const clientEntry = fs.readFileSync(
+  path.join(__dirname, '../src/index.jsx'),
+  'utf8'
+);
 
 test('service worker uses network-first handling before generic cache lookup for navigations', () => {
   const fetchHandlerIndex = serviceWorker.indexOf("self.addEventListener('fetch'");
@@ -26,7 +30,8 @@ test('service worker uses network-first handling before generic cache lookup for
 
 test('service worker cache name is bumped so old app-shell caches are discarded', () => {
   assert.doesNotMatch(serviceWorker, /CACHE_NAME\s*=\s*['"]keeplocal-v1['"]/);
-  assert.match(serviceWorker, /CACHE_NAME\s*=\s*['"]keeplocal-v4['"]/);
+  assert.match(serviceWorker, /CACHE_NAME\s*=\s*['"]keeplocal-v5['"]/);
+  assert.match(serviceWorker, /cacheName\.startsWith\(['"]keeplocal-['"]\)/);
 });
 
 test('private uploaded images are never stored in the service worker cache', () => {
@@ -39,4 +44,9 @@ test('service worker keeps cache writes and lifecycle work alive', () => {
   assert.match(serviceWorker, /await cache\.put\(request, response\.clone\(\)\)/);
   assert.match(serviceWorker, /Promise\.all\(\[precache, self\.skipWaiting\(\)\]\)/);
   assert.match(serviceWorker, /Promise\.all\(\[cleanup, self\.clients\.claim\(\)\]\)/);
+});
+
+test('service worker updates bypass browser HTTP caches', () => {
+  assert.match(clientEntry, /updateViaCache:\s*['"]none['"]/);
+  assert.match(clientEntry, /await registration\.update\(\)/);
 });

--- a/client/tests/vercelDeployment.test.js
+++ b/client/tests/vercelDeployment.test.js
@@ -46,6 +46,18 @@ test('Vercel applies static security headers and never caches private demo data'
   }
 });
 
+test('Vercel never serves a stale service worker', () => {
+  const config = JSON.parse(fs.readFileSync(path.join(root, 'vercel.json'), 'utf8'));
+  const serviceWorkerHeaders = config.headers.find(
+    ({ source }) => source === '/service-worker.js'
+  )?.headers || [];
+  const asMap = (headers) => Object.fromEntries(headers.map(({ key, value }) => [key, value]));
+  const headers = asMap(serviceWorkerHeaders);
+
+  assert.equal(headers['Cache-Control'], 'no-cache, no-store, must-revalidate');
+  assert.equal(headers['Service-Worker-Allowed'], '/');
+});
+
 test('Vite exposes the legacy API URL without exposing arbitrary environment variables', async () => {
   const configUrl = pathToFileURL(path.join(root, 'vite.config.mjs')).href;
   const { default: config } = await import(configUrl);

--- a/client/vercel.json
+++ b/client/vercel.json
@@ -44,6 +44,19 @@
       ]
     },
     {
+      "source": "/service-worker.js",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache, no-store, must-revalidate"
+        },
+        {
+          "key": "Service-Worker-Allowed",
+          "value": "/"
+        }
+      ]
+    },
+    {
       "source": "/api/:path*",
       "headers": [
         {


### PR DESCRIPTION
## What changed

- fall back safely when access to `navigator.language` is blocked or unavailable
- force service-worker update checks past browser HTTP caches and rotate the app cache to `keeplocal-v5`
- keep cache cleanup scoped to KeepLocal
- add a one-click recovery action that unregisters the worker and clears only KeepLocal app caches
- show a non-sensitive diagnostic code on the fallback screen
- align the recovery UI with the current responsive hand-drawn design

## Root cause

The production client read `navigator.language` directly during initial React state creation. Privacy-restricted browsers can throw a `SecurityError` from that getter, producing the generic ErrorBoundary screen before login. An unchanged service-worker cache namespace could also leave installed PWA clients on stale shell state.

## User impact

The demo now starts with a German fallback when the browser blocks language access. If a different startup failure occurs, users can repair the cached web app in one click without clearing account cookies or note data.

## Verification

- client: 42/42 tests
- server: 55/55 tests
- ESLint: passed
- Vite production build: passed
- Chromium desktop 1440×900 and mobile 390×844: passed with both `navigator.language` and Local Storage forced to throw
- browser recovery action verified to unregister the worker, delete `keeplocal-v5`, and reload with a cache-busting URL