### PR TITLE
Harden browser startup TypeError paths

### DIFF
--- a/client/public/service-worker.js
+++ b/client/public/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'keeplocal-v5';
+const CACHE_NAME = 'keeplocal-v6';
 const urlsToCache = [
   '/',
   '/index.html',

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -23,6 +23,8 @@ import { SettingsProvider } from './contexts/SettingsContext';
 import { initializeCSRF, notesAPI } from './services/api';
 import { useKeyboardShortcuts } from './hooks';
 import { readLocalStorage, writeLocalStorage } from './utils/localStorage.mjs';
+import { applyThemeToDocument, getBrowserPathname } from './utils/browserEnvironment.mjs';
+import { normalizeNote, normalizeNotesPayload } from './utils/notesPayload.mjs';
 
 const THEMES = new Set(['light', 'dark', 'oled', 'eink', 'doodle']);
 
@@ -69,20 +71,7 @@ function AppContent() {
 
   // Theme anwenden
   useEffect(() => {
-    // Remove all theme classes
-    document.body.classList.remove('dark-mode', 'oled-mode', 'eink-mode', 'doodle-mode');
-
-    // Add appropriate theme class
-    if (theme === 'dark') {
-      document.body.classList.add('dark-mode');
-    } else if (theme === 'oled') {
-      document.body.classList.add('oled-mode');
-    } else if (theme === 'eink') {
-      document.body.classList.add('eink-mode');
-    } else if (theme === 'doodle') {
-      document.body.classList.add('doodle-mode');
-    }
-
+    applyThemeToDocument(theme);
     writeLocalStorage('theme', theme);
   }, [theme]);
 
@@ -103,10 +92,11 @@ function AppContent() {
 
       const response = await notesAPI.getAll(params);
       if (requestSequence !== fetchSequenceRef.current) return;
-      setNotes(response.notes || []);
-      setPagination(response.pagination || { page: 1, limit: 50, total: 0, pages: 0 });
-      setNoteCounts(response.counts || { active: 0, archived: 0 });
-      setAllTags(response.tags || []);
+      const normalized = normalizeNotesPayload(response);
+      setNotes(normalized.notes);
+      setPagination(normalized.pagination);
+      setNoteCounts(normalized.counts);
+      setAllTags(normalized.tags);
     } catch (error) {
       if (requestSequence !== fetchSequenceRef.current) return;
       console.error('Fehler beim Laden der Notizen:', error);
@@ -179,7 +169,8 @@ function AppContent() {
   const togglePinNote = async (id) => {
     setOperationLoading(prev => ({ ...prev, [id]: 'pin' }));
     try {
-      const response = await notesAPI.togglePin(id);
+      const response = normalizeNote(await notesAPI.togglePin(id));
+      if (!response) throw new Error('Ungültige Serverantwort');
       setNotes(prev => prev.map(note => note._id === id ? response : note));
       const message = response.isPinned ? t('notePinned') : t('noteUnpinned');
       showToast(message, 'success');
@@ -221,7 +212,9 @@ function AppContent() {
 
   // Wenn eine Notiz geteilt wurde, aktualisieren
   const handleNoteShared = (updatedNote) => {
-    setNotes(prev => prev.map(note => note._id === updatedNote._id ? updatedNote : note));
+    const normalized = normalizeNote(updatedNote);
+    if (!normalized) return;
+    setNotes(prev => prev.map(note => note._id === normalized._id ? normalized : note));
   };
 
   // Modal handlers
@@ -364,7 +357,7 @@ function AppContent() {
   };
 
   // Handle OAuth callback route
-  const isOAuthCallback = window.location.pathname === '/oauth/callback';
+  const isOAuthCallback = getBrowserPathname() === '/oauth/callback';
   if (isOAuthCallback) {
     return (
       <OAuthCallback

--- a/client/src/components/ErrorBoundary.css
+++ b/client/src/components/ErrorBoundary.css
@@ -54,9 +54,13 @@
   line-height: var(--leading-relaxed);
 }
 
+.error-boundary-diagnostics {
+  margin: 0 0 var(--space-5);
+}
+
 .error-boundary-diagnostic {
   display: inline-block;
-  margin: 0 0 var(--space-5);
+  margin: 0;
   padding: var(--space-2) var(--space-3);
   border: 1px dashed var(--border-color-strong);
   border-radius: var(--radius-sm);
@@ -69,6 +73,21 @@
   color: var(--text-primary);
   font-family: var(--font-mono);
   font-weight: var(--font-semibold);
+}
+
+.error-boundary-hint {
+  margin: var(--space-3) auto 0;
+  max-width: 500px;
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: var(--leading-relaxed);
+}
+
+.error-boundary-hint code {
+  overflow-wrap: anywhere;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 0.9em;
 }
 
 .error-boundary-details {

--- a/client/src/components/ErrorBoundary.jsx
+++ b/client/src/components/ErrorBoundary.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import './ErrorBoundary.css';
-import { repairAppCaches } from '../utils/appRecovery.mjs';
+import { repairAppState } from '../utils/appRecovery.mjs';
 import { buildErrorDiagnostic } from '../utils/errorDiagnostic.mjs';
 
 class ErrorBoundary extends React.Component {
@@ -54,7 +54,7 @@ class ErrorBoundary extends React.Component {
     this.setState({ isRepairing: true, repairFailed: false });
 
     try {
-      await repairAppCaches();
+      await repairAppState();
       const url = new URL(window.location.href);
       url.searchParams.set('app-repair', Date.now().toString(36));
       window.location.replace(url.toString());
@@ -78,10 +78,17 @@ class ErrorBoundary extends React.Component {
             </p>
 
             {this.state.diagnostic && (
-              <p className="error-boundary-diagnostic">
-                Diagnose: <code>{this.state.diagnostic.code}</code>
-                {' · '}{this.state.diagnostic.name}
-              </p>
+              <div className="error-boundary-diagnostics">
+                <p className="error-boundary-diagnostic">
+                  Diagnose: <code>{this.state.diagnostic.code}</code>
+                  {' · '}{this.state.diagnostic.name}
+                </p>
+                {this.state.diagnostic.message && (
+                  <p className="error-boundary-hint">
+                    Technischer Hinweis: <code>{this.state.diagnostic.message}</code>
+                  </p>
+                )}
+              </div>
             )}
 
             {import.meta.env.DEV && this.state.error && (
@@ -128,7 +135,8 @@ class ErrorBoundary extends React.Component {
             )}
 
             <p className="error-boundary-help">
-              „App sicher aktualisieren“ erneuert nur die Web-App. Konto und Notizen bleiben erhalten.
+              „App sicher aktualisieren“ erneuert die Web-App und setzt lokale Anzeigeoptionen zurück.
+              Konto und Notizen bleiben erhalten.
             </p>
           </div>
         </div>

--- a/client/src/contexts/LanguageContext.jsx
+++ b/client/src/contexts/LanguageContext.jsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { translations, defaultLanguage } from '../translations';
 import { getBrowserLanguage } from '../utils/browserLanguage.mjs';
+import { subscribeToWindowEvent } from '../utils/browserEnvironment.mjs';
 
 const LanguageContext = createContext();
 
@@ -15,8 +16,7 @@ export function LanguageProvider({ children }) {
       setLanguage(resolveLanguage());
     }
 
-    window.addEventListener('languagechange', handleLanguageChange);
-    return () => window.removeEventListener('languagechange', handleLanguageChange);
+    return subscribeToWindowEvent('languagechange', handleLanguageChange);
   }, []);
 
   const t = (key) => {

--- a/client/src/contexts/SettingsContext.jsx
+++ b/client/src/contexts/SettingsContext.jsx
@@ -6,15 +6,9 @@
 
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { readLocalStorage, writeLocalStorage } from '../utils/localStorage.mjs';
+import { DEFAULT_SETTINGS, normalizeSettings } from '../utils/settingsPayload.mjs';
 
 const SettingsContext = createContext();
-
-const DEFAULT_SETTINGS = {
-  aiFeatures: {
-    voiceTranscription: false,  // Opt-in for Whisper voice-to-text
-  },
-  transcriptionLanguage: 'auto',  // Language for transcription (auto = auto-detect)
-};
 
 export function SettingsProvider({ children }) {
   const [settings, setSettings] = useState(() => {
@@ -22,13 +16,13 @@ export function SettingsProvider({ children }) {
     const savedSettings = readLocalStorage('keeplocal_settings');
     if (savedSettings) {
       try {
-        return { ...DEFAULT_SETTINGS, ...JSON.parse(savedSettings) };
+        return normalizeSettings(JSON.parse(savedSettings));
       } catch (error) {
         console.error('Error parsing settings from localStorage:', error);
         return DEFAULT_SETTINGS;
       }
     }
-    return DEFAULT_SETTINGS;
+    return normalizeSettings(DEFAULT_SETTINGS);
   });
 
   // Save to localStorage whenever settings change

--- a/client/src/hooks/useKeyboardShortcuts.js
+++ b/client/src/hooks/useKeyboardShortcuts.js
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { subscribeToWindowEvent } from '../utils/browserEnvironment.mjs';
 
 /**
  * Hook for registering global keyboard shortcuts
@@ -50,8 +51,7 @@ export function useKeyboardShortcuts(shortcuts = {}, enabled = true) {
       }
     };
 
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
+    return subscribeToWindowEvent('keydown', handleKeyDown);
   }, [shortcuts, enabled]);
 }
 

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -26,7 +26,9 @@ if ('serviceWorker' in navigator && import.meta.env.PROD) {
         '/service-worker.js',
         { updateViaCache: 'none' }
       );
-      await registration.update();
+      if (typeof registration?.update === 'function') {
+        await registration.update();
+      }
     } catch (error) {
       console.error('Service worker registration failed:', error);
     }

--- a/client/src/utils/appRecovery.mjs
+++ b/client/src/utils/appRecovery.mjs
@@ -1,4 +1,5 @@
 export const APP_CACHE_PREFIX = 'keeplocal-';
+export const APP_PREFERENCE_KEYS = ['theme', 'keeplocal_settings', 'token'];
 
 async function unregisterServiceWorkers(environment) {
   let serviceWorker;
@@ -69,11 +70,38 @@ async function removeAppCaches(environment) {
   }
 }
 
-export async function repairAppCaches(environment = globalThis) {
+function removeAppPreferences(environment) {
+  let storage;
+
+  try {
+    storage = environment?.localStorage;
+  } catch {
+    return 0;
+  }
+
+  if (!storage || typeof storage.removeItem !== 'function') return 0;
+
+  let removedPreferences = 0;
+  for (const key of APP_PREFERENCE_KEYS) {
+    try {
+      storage.removeItem(key);
+      removedPreferences += 1;
+    } catch {
+      // Keep repairing the remaining app state when one key is blocked.
+    }
+  }
+
+  return removedPreferences;
+}
+
+export async function repairAppState(environment = globalThis) {
   const [unregisteredWorkers, removedCaches] = await Promise.all([
     unregisterServiceWorkers(environment),
     removeAppCaches(environment)
   ]);
+  const removedPreferences = removeAppPreferences(environment);
 
-  return { unregisteredWorkers, removedCaches };
+  return { unregisteredWorkers, removedCaches, removedPreferences };
 }
+
+export const repairAppCaches = repairAppState;

--- a/client/src/utils/browserEnvironment.mjs
+++ b/client/src/utils/browserEnvironment.mjs
@@ -1,0 +1,67 @@
+const THEME_CLASSES = ['dark-mode', 'oled-mode', 'eink-mode', 'doodle-mode'];
+const THEME_CLASS_BY_NAME = {
+  dark: 'dark-mode',
+  oled: 'oled-mode',
+  eink: 'eink-mode',
+  doodle: 'doodle-mode'
+};
+
+function resolveGlobalProperty(propertyName) {
+  try {
+    return globalThis[propertyName] || null;
+  } catch {
+    return null;
+  }
+}
+
+export function applyThemeToDocument(theme, documentObject = resolveGlobalProperty('document')) {
+  try {
+    const classList = documentObject?.body?.classList;
+    if (!classList || typeof classList.remove !== 'function') return false;
+
+    classList.remove(...THEME_CLASSES);
+    const themeClass = THEME_CLASS_BY_NAME[theme];
+    if (themeClass) {
+      if (typeof classList.add !== 'function') return false;
+      classList.add(themeClass);
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function getBrowserPathname(windowObject = resolveGlobalProperty('window')) {
+  try {
+    const pathname = windowObject?.location?.pathname;
+    return typeof pathname === 'string' ? pathname : '/';
+  } catch {
+    return '/';
+  }
+}
+
+export function subscribeToWindowEvent(
+  eventName,
+  listener,
+  windowObject = resolveGlobalProperty('window')
+) {
+  try {
+    if (!windowObject || typeof windowObject.addEventListener !== 'function') {
+      return () => {};
+    }
+
+    windowObject.addEventListener(eventName, listener);
+    return () => {
+      try {
+        if (typeof windowObject.removeEventListener === 'function') {
+          windowObject.removeEventListener(eventName, listener);
+        }
+      } catch {
+        // The browser may revoke access while the page is open.
+      }
+    };
+  } catch {
+    return () => {};
+  }
+}

--- a/client/src/utils/errorDiagnostic.mjs
+++ b/client/src/utils/errorDiagnostic.mjs
@@ -6,6 +6,27 @@ function safeErrorValue(readValue, fallback = '') {
   }
 }
 
+const SAFE_MESSAGE_ERROR_NAMES = new Set([
+  'TypeError',
+  'ReferenceError',
+  'RangeError',
+  'SyntaxError',
+  'SecurityError',
+  'NotSupportedError',
+  'InvalidStateError'
+]);
+
+function redactErrorMessage(message) {
+  return message
+    .replace(/https?:\/\/[^\s)]+/gi, '[URL]')
+    .replace(/[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/gi, '[E-Mail]')
+    .replace(/\b[a-z0-9_-]{32,}\b/gi, '[Wert]')
+    .replace(/(["'`])([^\n]{40,})\1/g, '$1[Wert]$1')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 220);
+}
+
 export function buildErrorDiagnostic(error, errorInfo) {
   const name = safeErrorValue(() => error?.name, 'Error')
     .replace(/[^a-z0-9_.-]/gi, '')
@@ -22,6 +43,7 @@ export function buildErrorDiagnostic(error, errorInfo) {
 
   return {
     code: `KL-${(hash >>> 0).toString(16).padStart(8, '0').toUpperCase()}`,
-    name
+    name,
+    message: SAFE_MESSAGE_ERROR_NAMES.has(name) ? redactErrorMessage(message) : ''
   };
 }

--- a/client/src/utils/notesPayload.mjs
+++ b/client/src/utils/notesPayload.mjs
@@ -1,0 +1,129 @@
+const DEFAULT_PAGINATION = { page: 1, limit: 50, total: 0, pages: 0 };
+const DEFAULT_COUNTS = { active: 0, archived: 0 };
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function asText(value, fallback = '') {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function asNonNegativeNumber(value, fallback = 0) {
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+
+function normalizeTodoItem(item) {
+  if (!isRecord(item)) return null;
+
+  return {
+    ...item,
+    text: asText(item.text),
+    completed: Boolean(item.completed)
+  };
+}
+
+function normalizeImage(image) {
+  if (!isRecord(image)) return null;
+  const url = asText(image.url);
+  const thumbnailUrl = asText(image.thumbnailUrl);
+  if (!url && !thumbnailUrl) return null;
+
+  return {
+    ...image,
+    url,
+    thumbnailUrl,
+    filename: asText(image.filename, 'Bild')
+  };
+}
+
+function normalizeLinkPreview(preview) {
+  if (!isRecord(preview) || typeof preview.url !== 'string') return null;
+
+  return {
+    ...preview,
+    url: preview.url,
+    title: asText(preview.title),
+    description: asText(preview.description),
+    image: asText(preview.image),
+    siteName: asText(preview.siteName)
+  };
+}
+
+function normalizeSharedUser(user) {
+  if (typeof user === 'string') return user;
+  if (!isRecord(user)) return null;
+
+  return {
+    ...user,
+    username: asText(user.username),
+    email: asText(user.email)
+  };
+}
+
+export function normalizeNote(note) {
+  if (!isRecord(note)) return null;
+  const id = asText(note._id, asText(note.id));
+  if (!id) return null;
+
+  return {
+    ...note,
+    _id: id,
+    title: asText(note.title),
+    content: asText(note.content),
+    color: asText(note.color, '#ffffff'),
+    isPinned: Boolean(note.isPinned),
+    isArchived: Boolean(note.isArchived),
+    isTodoList: Boolean(note.isTodoList),
+    todoItems: Array.isArray(note.todoItems)
+      ? note.todoItems.map(normalizeTodoItem).filter(Boolean)
+      : [],
+    tags: Array.isArray(note.tags)
+      ? note.tags.filter(tag => typeof tag === 'string')
+      : [],
+    images: Array.isArray(note.images)
+      ? note.images.map(normalizeImage).filter(Boolean)
+      : [],
+    linkPreviews: Array.isArray(note.linkPreviews)
+      ? note.linkPreviews.map(normalizeLinkPreview).filter(Boolean)
+      : [],
+    sharedWith: Array.isArray(note.sharedWith)
+      ? note.sharedWith.map(normalizeSharedUser).filter(Boolean)
+      : []
+  };
+}
+
+function normalizeTag(tag) {
+  if (!isRecord(tag) || typeof tag.name !== 'string' || !tag.name) return null;
+
+  return {
+    ...tag,
+    name: tag.name,
+    count: asNonNegativeNumber(tag.count)
+  };
+}
+
+export function normalizeNotesPayload(payload) {
+  const source = isRecord(payload) ? payload : {};
+  const pagination = isRecord(source.pagination) ? source.pagination : {};
+  const counts = isRecord(source.counts) ? source.counts : {};
+
+  return {
+    notes: Array.isArray(source.notes)
+      ? source.notes.map(normalizeNote).filter(Boolean)
+      : [],
+    pagination: {
+      page: asNonNegativeNumber(pagination.page, DEFAULT_PAGINATION.page),
+      limit: asNonNegativeNumber(pagination.limit, DEFAULT_PAGINATION.limit),
+      total: asNonNegativeNumber(pagination.total, DEFAULT_PAGINATION.total),
+      pages: asNonNegativeNumber(pagination.pages, DEFAULT_PAGINATION.pages)
+    },
+    counts: {
+      active: asNonNegativeNumber(counts.active, DEFAULT_COUNTS.active),
+      archived: asNonNegativeNumber(counts.archived, DEFAULT_COUNTS.archived)
+    },
+    tags: Array.isArray(source.tags)
+      ? source.tags.map(normalizeTag).filter(Boolean)
+      : []
+  };
+}

--- a/client/src/utils/settingsPayload.mjs
+++ b/client/src/utils/settingsPayload.mjs
@@ -1,0 +1,29 @@
+export const DEFAULT_SETTINGS = {
+  aiFeatures: {
+    voiceTranscription: false
+  },
+  transcriptionLanguage: 'auto'
+};
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function normalizeSettings(value) {
+  const source = isRecord(value) ? value : {};
+  const aiFeatures = isRecord(source.aiFeatures) ? source.aiFeatures : {};
+  const transcriptionLanguage = typeof source.transcriptionLanguage === 'string'
+    && source.transcriptionLanguage.length <= 20
+    ? source.transcriptionLanguage
+    : DEFAULT_SETTINGS.transcriptionLanguage;
+
+  return {
+    ...DEFAULT_SETTINGS,
+    ...source,
+    aiFeatures: {
+      ...DEFAULT_SETTINGS.aiFeatures,
+      voiceTranscription: aiFeatures.voiceTranscription === true
+    },
+    transcriptionLanguage
+  };
+}

--- a/client/tests/appRecovery.test.js
+++ b/client/tests/appRecovery.test.js
@@ -7,8 +7,8 @@ const moduleUrl = pathToFileURL(
   path.join(__dirname, '../src/utils/appRecovery.mjs')
 ).href;
 
-test('app recovery unregisters workers and removes only KeepLocal caches', async () => {
-  const { repairAppCaches } = await import(moduleUrl);
+test('app recovery unregisters workers and resets only KeepLocal browser state', async () => {
+  const { repairAppState } = await import(moduleUrl);
   const calls = [];
   const environment = {
     navigator: {
@@ -29,20 +29,37 @@ test('app recovery unregisters workers and removes only KeepLocal caches', async
         calls.push(cacheName);
         return true;
       }
+    },
+    localStorage: {
+      removeItem(key) {
+        calls.push(`preference:${key}`);
+      }
     }
   };
 
-  const result = await repairAppCaches(environment);
+  const result = await repairAppState(environment);
 
-  assert.deepEqual(result, { unregisteredWorkers: 1, removedCaches: 2 });
+  assert.deepEqual(result, {
+    unregisteredWorkers: 1,
+    removedCaches: 2,
+    removedPreferences: 3
+  });
   assert.deepEqual(
     calls.sort(),
-    ['keeplocal-v4', 'keeplocal-v5', 'worker-1', 'worker-2'].sort()
+    [
+      'keeplocal-v4',
+      'keeplocal-v5',
+      'preference:keeplocal_settings',
+      'preference:theme',
+      'preference:token',
+      'worker-1',
+      'worker-2'
+    ].sort()
   );
 });
 
 test('app recovery remains usable when browser APIs are blocked', async () => {
-  const { repairAppCaches } = await import(moduleUrl);
+  const { repairAppState } = await import(moduleUrl);
   const environment = {};
 
   Object.defineProperty(environment, 'navigator', {
@@ -55,11 +72,16 @@ test('app recovery remains usable when browser APIs are blocked', async () => {
       throw new DOMException('Blocked', 'SecurityError');
     }
   });
+  Object.defineProperty(environment, 'localStorage', {
+    get() {
+      throw new DOMException('Blocked', 'SecurityError');
+    }
+  });
 
   await assert.doesNotReject(async () => {
     assert.deepEqual(
-      await repairAppCaches(environment),
-      { unregisteredWorkers: 0, removedCaches: 0 }
+      await repairAppState(environment),
+      { unregisteredWorkers: 0, removedCaches: 0, removedPreferences: 0 }
     );
   });
 });

--- a/client/tests/browserEnvironment.test.js
+++ b/client/tests/browserEnvironment.test.js
@@ -1,0 +1,54 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const test = require('node:test');
+const { pathToFileURL } = require('node:url');
+
+const moduleUrl = pathToFileURL(
+  path.join(__dirname, '../src/utils/browserEnvironment.mjs')
+).href;
+
+test('browser environment applies supported themes without trusting DOM methods', async () => {
+  const { applyThemeToDocument } = await import(moduleUrl);
+  const calls = [];
+  const documentObject = {
+    body: {
+      classList: {
+        remove(...themes) {
+          calls.push(['remove', ...themes]);
+        },
+        add(theme) {
+          calls.push(['add', theme]);
+        }
+      }
+    }
+  };
+
+  assert.equal(applyThemeToDocument('doodle', documentObject), true);
+  assert.deepEqual(calls, [
+    ['remove', 'dark-mode', 'oled-mode', 'eink-mode', 'doodle-mode'],
+    ['add', 'doodle-mode']
+  ]);
+  assert.equal(applyThemeToDocument('unknown', documentObject), true);
+  assert.equal(applyThemeToDocument('dark', { body: {} }), false);
+});
+
+test('browser environment tolerates blocked location and event APIs', async () => {
+  const { getBrowserPathname, subscribeToWindowEvent } = await import(moduleUrl);
+  const windowObject = {};
+
+  Object.defineProperty(windowObject, 'location', {
+    get() {
+      throw new DOMException('Blocked', 'SecurityError');
+    }
+  });
+  Object.defineProperty(windowObject, 'addEventListener', {
+    get() {
+      throw new TypeError('addEventListener is unavailable');
+    }
+  });
+
+  assert.equal(getBrowserPathname(windowObject), '/');
+  const cleanup = subscribeToWindowEvent('keydown', () => {}, windowObject);
+  assert.equal(typeof cleanup, 'function');
+  assert.doesNotThrow(cleanup);
+});

--- a/client/tests/errorBoundaryRecovery.test.js
+++ b/client/tests/errorBoundaryRecovery.test.js
@@ -13,9 +13,10 @@ const styles = fs.readFileSync(
 );
 
 test('error boundary offers safe cache recovery and a non-sensitive diagnostic', () => {
-  assert.match(component, /repairAppCaches/);
+  assert.match(component, /repairAppState/);
   assert.match(component, /App sicher aktualisieren/);
   assert.match(component, /diagnostic\.code/);
+  assert.match(component, /Technischer Hinweis/);
   assert.doesNotMatch(component, /Browser-Cache leeren/);
   assert.match(styles, /\.error-boundary-button:focus-visible/);
 });

--- a/client/tests/errorDiagnostic.test.js
+++ b/client/tests/errorDiagnostic.test.js
@@ -9,7 +9,7 @@ const moduleUrl = pathToFileURL(
 
 test('error diagnostics are stable and do not expose the error message', async () => {
   const { buildErrorDiagnostic } = await import(moduleUrl);
-  const error = new DOMException('private page details', 'SecurityError');
+  const error = new Error('private page details');
   const errorInfo = { componentStack: '\n    at LanguageProvider' };
 
   const first = buildErrorDiagnostic(error, errorInfo);
@@ -17,6 +17,22 @@ test('error diagnostics are stable and do not expose the error message', async (
 
   assert.deepEqual(first, second);
   assert.match(first.code, /^KL-[0-9A-F]{8}$/);
-  assert.equal(first.name, 'SecurityError');
+  assert.equal(first.name, 'Error');
+  assert.equal(first.message, '');
   assert.doesNotMatch(JSON.stringify(first), /private page details/);
+});
+
+test('error diagnostics show a bounded redacted TypeError hint', async () => {
+  const { buildErrorDiagnostic } = await import(moduleUrl);
+  const error = new TypeError(
+    'Failed for https://private.example/path user@example.com abcdefghijklmnopqrstuvwxyz123456'
+  );
+
+  const diagnostic = buildErrorDiagnostic(error, {});
+
+  assert.equal(diagnostic.name, 'TypeError');
+  assert.match(diagnostic.message, /\[URL\]/);
+  assert.match(diagnostic.message, /\[E-Mail\]/);
+  assert.match(diagnostic.message, /\[Wert\]/);
+  assert.doesNotMatch(diagnostic.message, /private\.example|user@example\.com|abcdefghijklmnopqrstuvwxyz/);
 });

--- a/client/tests/notesPayload.test.js
+++ b/client/tests/notesPayload.test.js
@@ -1,0 +1,61 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const test = require('node:test');
+const { pathToFileURL } = require('node:url');
+
+const moduleUrl = pathToFileURL(
+  path.join(__dirname, '../src/utils/notesPayload.mjs')
+).href;
+
+test('notes payload normalization makes malformed API collections render-safe', async () => {
+  const { normalizeNotesPayload } = await import(moduleUrl);
+  const payload = {
+    notes: [
+      null,
+      {
+        _id: 'note-1',
+        title: 42,
+        content: null,
+        tags: ['valid', null, 2],
+        images: 'not-an-array',
+        todoItems: [{ text: 'Keep', completed: true }, null, 'bad'],
+        linkPreviews: [{ url: 'https://example.test' }, null],
+        sharedWith: [{ username: 'tester' }, null]
+      }
+    ],
+    tags: null,
+    pagination: { page: 'bad', limit: 50, pages: 4, total: 9 },
+    counts: { active: 8, archived: 'bad' }
+  };
+
+  const normalized = normalizeNotesPayload(payload);
+
+  assert.equal(normalized.notes.length, 1);
+  assert.equal(normalized.notes[0].title, '');
+  assert.equal(normalized.notes[0].content, '');
+  assert.deepEqual(normalized.notes[0].tags, ['valid']);
+  assert.deepEqual(normalized.notes[0].images, []);
+  assert.deepEqual(normalized.notes[0].todoItems, [{ text: 'Keep', completed: true }]);
+  assert.deepEqual(normalized.notes[0].linkPreviews, [{
+    url: 'https://example.test',
+    title: '',
+    description: '',
+    image: '',
+    siteName: ''
+  }]);
+  assert.deepEqual(normalized.notes[0].sharedWith, [{ username: 'tester', email: '' }]);
+  assert.deepEqual(normalized.tags, []);
+  assert.deepEqual(normalized.pagination, { page: 1, limit: 50, pages: 4, total: 9 });
+  assert.deepEqual(normalized.counts, { active: 8, archived: 0 });
+});
+
+test('notes payload normalization supplies a safe empty response', async () => {
+  const { normalizeNotesPayload } = await import(moduleUrl);
+
+  assert.deepEqual(normalizeNotesPayload(null), {
+    notes: [],
+    pagination: { page: 1, limit: 50, total: 0, pages: 0 },
+    counts: { active: 0, archived: 0 },
+    tags: []
+  });
+});

--- a/client/tests/serviceWorkerCacheStrategy.test.js
+++ b/client/tests/serviceWorkerCacheStrategy.test.js
@@ -30,7 +30,7 @@ test('service worker uses network-first handling before generic cache lookup for
 
 test('service worker cache name is bumped so old app-shell caches are discarded', () => {
   assert.doesNotMatch(serviceWorker, /CACHE_NAME\s*=\s*['"]keeplocal-v1['"]/);
-  assert.match(serviceWorker, /CACHE_NAME\s*=\s*['"]keeplocal-v5['"]/);
+  assert.match(serviceWorker, /CACHE_NAME\s*=\s*['"]keeplocal-v6['"]/);
   assert.match(serviceWorker, /cacheName\.startsWith\(['"]keeplocal-['"]\)/);
 });
 
@@ -48,5 +48,6 @@ test('service worker keeps cache writes and lifecycle work alive', () => {
 
 test('service worker updates bypass browser HTTP caches', () => {
   assert.match(clientEntry, /updateViaCache:\s*['"]none['"]/);
+  assert.match(clientEntry, /typeof registration\?\.update === ['"]function['"]/);
   assert.match(clientEntry, /await registration\.update\(\)/);
 });

--- a/client/tests/settingsPayload.test.js
+++ b/client/tests/settingsPayload.test.js
@@ -1,0 +1,28 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const test = require('node:test');
+const { pathToFileURL } = require('node:url');
+
+const moduleUrl = pathToFileURL(
+  path.join(__dirname, '../src/utils/settingsPayload.mjs')
+).href;
+
+test('settings normalization repairs malformed persisted values', async () => {
+  const { DEFAULT_SETTINGS, normalizeSettings } = await import(moduleUrl);
+
+  assert.deepEqual(normalizeSettings(null), DEFAULT_SETTINGS);
+  assert.deepEqual(
+    normalizeSettings({ aiFeatures: 'yes', transcriptionLanguage: 42 }),
+    DEFAULT_SETTINGS
+  );
+});
+
+test('settings normalization preserves valid supported values', async () => {
+  const { normalizeSettings } = await import(moduleUrl);
+  const settings = {
+    aiFeatures: { voiceTranscription: true },
+    transcriptionLanguage: 'de'
+  };
+
+  assert.deepEqual(normalizeSettings(settings), settings);
+});

--- a/client/tests/themeModes.test.js
+++ b/client/tests/themeModes.test.js
@@ -11,12 +11,15 @@ function readClientFile(...parts) {
 
 test('theme cycle includes doodle mode after e-ink and applies the body class', () => {
   const app = readClientFile('src/App.jsx');
+  const browserEnvironment = readClientFile('src/utils/browserEnvironment.mjs');
 
   assert.match(app, /readLocalStorage\('theme'\)/);
   assert.match(app, /THEMES\.has\(savedTheme\) \? savedTheme : 'light'/);
-  assert.match(app, /classList\.remove\('dark-mode', 'oled-mode', 'eink-mode', 'doodle-mode'\)/);
-  assert.match(app, /theme === 'doodle'/);
-  assert.match(app, /classList\.add\('doodle-mode'\)/);
+  assert.match(app, /applyThemeToDocument\(theme\)/);
+  assert.match(browserEnvironment, /'dark-mode', 'oled-mode', 'eink-mode', 'doodle-mode'/);
+  assert.match(browserEnvironment, /doodle:\s*'doodle-mode'/);
+  assert.match(browserEnvironment, /classList\.remove\(\.\.\.THEME_CLASSES\)/);
+  assert.match(browserEnvironment, /classList\.add\(themeClass\)/);
   assert.match(app, /prevTheme === 'eink'\) return 'doodle'/);
   assert.match(app, /prevTheme === 'doodle'\) return 'light'/);
 });


### PR DESCRIPTION
## What changed

- guard theme, location, language-change, keyboard, and service-worker browser APIs
- normalize persisted settings and all note collections before React renders them
- normalize direct note mutation responses before they enter app state
- make “App sicher aktualisieren” also reset KeepLocal-only display preferences
- show a bounded, redacted technical hint for safe runtime error types
- bump the PWA cache so affected browsers receive the repaired bundle

## Root cause

The browser-specific diagnostic fingerprint `KL-CFB6ABA7` cannot be inverted into one stable raw stack across engines. The startup path still trusted several browser APIs, persisted settings, and API collection shapes that can throw a `TypeError` in privacy-restricted or stale-client states. These trust boundaries are now fail-safe and covered independently.

## User impact

Affected visitors should reach the login/demo UI even with blocked storage, language, DOM event, or service-worker APIs. Malformed/stale note and settings data can no longer crash the React tree. Account data and server-side notes are never removed by recovery.

## Verification

- client: 49/49 tests
- server: 55/55 tests
- AI routes: 4/4 tests
- ESLint: passed
- Vite production build: passed
- Chromium desktop and 390px mobile: no page errors, ErrorBoundary, error toasts, or horizontal overflow
- restricted browser APIs, corrupt persisted settings, and malformed demo payloads exercised