### PR TITLE
Add standalone stale-app recovery

### DIFF
--- a/client/public/recover.css
+++ b/client/public/recover.css
@@ -1,0 +1,220 @@
+:root {
+  color-scheme: light;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #172033;
+  background: #eef5f8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-width: 280px;
+  min-height: 100vh;
+  margin: 0;
+  background:
+    linear-gradient(rgba(38, 61, 91, 0.035) 1px, transparent 1px),
+    #eef5f8;
+  background-size: 100% 32px;
+}
+
+button,
+a {
+  font: inherit;
+}
+
+.recovery-shell {
+  display: grid;
+  min-height: 100vh;
+  padding: 32px 20px;
+  place-items: center;
+}
+
+.recovery-card {
+  position: relative;
+  width: min(100%, 560px);
+  padding: clamp(28px, 6vw, 48px);
+  overflow: hidden;
+  border: 2px solid #263d5b;
+  border-radius: 10px 7px 12px 8px;
+  background: #ffffff;
+  box-shadow: 8px 8px 0 rgba(38, 61, 91, 0.14);
+}
+
+.recovery-card::before,
+.recovery-card::after {
+  position: absolute;
+  top: 18px;
+  right: -18px;
+  width: 88px;
+  height: 3px;
+  background: #f4a63a;
+  content: "";
+  transform: rotate(23deg);
+}
+
+.recovery-card::after {
+  top: 31px;
+  right: -8px;
+  width: 64px;
+  height: 2px;
+  background: #263d5b;
+}
+
+.recovery-kicker {
+  display: inline-block;
+  margin-bottom: 12px;
+  color: #8a4700;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 470px;
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(2rem, 7vw, 3rem);
+  line-height: 1.05;
+}
+
+.recovery-intro {
+  margin: 20px 0 24px;
+  color: #43506a;
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+.recovery-status {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  padding: 16px;
+  border: 1px dashed #6b7890;
+  border-radius: 8px 6px 9px 7px;
+  background: #f6f9fb;
+}
+
+.recovery-status-mark {
+  display: grid;
+  flex: 0 0 32px;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: #dce9f0;
+  color: #263d5b;
+  font-size: 1.35rem;
+  font-weight: 800;
+  place-items: center;
+}
+
+.recovery-status.is-complete .recovery-status-mark {
+  background: #dff1e2;
+  color: #166534;
+}
+
+.recovery-status.is-error .recovery-status-mark {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.recovery-status strong,
+.recovery-status p {
+  display: block;
+  margin: 0;
+}
+
+.recovery-status p {
+  margin-top: 4px;
+  color: #58657b;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.recovery-assurance {
+  display: grid;
+  gap: 4px;
+  margin: 22px 0;
+  color: #263d5b;
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.recovery-assurance span {
+  color: #58657b;
+}
+
+.recovery-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.recovery-actions button,
+.recovery-actions a {
+  min-height: 46px;
+  padding: 11px 18px;
+  border: 2px solid #263d5b;
+  border-radius: 6px 5px 7px 5px;
+  color: #172033;
+  font-weight: 750;
+  text-align: center;
+  text-decoration: none;
+}
+
+.recovery-actions button {
+  background: #f4a63a;
+  cursor: pointer;
+}
+
+.recovery-actions a {
+  background: #ffffff;
+}
+
+.recovery-actions button:hover,
+.recovery-actions a:hover {
+  transform: translateY(-1px);
+}
+
+.recovery-actions button:focus-visible,
+.recovery-actions a:focus-visible {
+  outline: 3px solid #49b6e5;
+  outline-offset: 3px;
+}
+
+.recovery-noscript {
+  margin: 18px 0 0;
+  color: #8a4700;
+  line-height: 1.5;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+@media (max-width: 480px) {
+  .recovery-shell {
+    align-items: start;
+    padding: 20px 12px;
+  }
+
+  .recovery-card {
+    padding: 28px 22px;
+    box-shadow: 5px 5px 0 rgba(38, 61, 91, 0.14);
+  }
+
+  .recovery-actions {
+    display: grid;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition: none !important;
+  }
+}

--- a/client/public/recover.html
+++ b/client/public/recover.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#eef5f8" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>KeepLocal sicher aktualisieren</title>
+    <link rel="stylesheet" href="/recover.css" />
+    <script src="/recover.js" defer></script>
+  </head>
+  <body>
+    <main class="recovery-shell">
+      <section class="recovery-card" aria-labelledby="recovery-title">
+        <span class="recovery-kicker">KeepLocal · Reparatur</span>
+        <h1 id="recovery-title">Web-App wird sicher aktualisiert</h1>
+        <p class="recovery-intro">
+          Alte App-Dateien und lokale Anzeigeoptionen werden entfernt. Danach öffnet sich
+          automatisch die aktuelle Version.
+        </p>
+
+        <div class="recovery-status" role="status" aria-live="polite" aria-atomic="true">
+          <span id="recovery-status-mark" class="recovery-status-mark" aria-hidden="true">↻</span>
+          <div>
+            <strong id="recovery-status-title">Reparatur läuft …</strong>
+            <p id="recovery-status-detail">Service Worker und KeepLocal-Cache werden geprüft.</p>
+          </div>
+        </div>
+
+        <div class="recovery-assurance">
+          <strong>Konto und Notizen bleiben erhalten.</strong>
+          <span>Serverdaten, Passwort und Sitzungscookie werden nicht verändert.</span>
+        </div>
+
+        <div class="recovery-actions">
+          <button id="recovery-retry" type="button" hidden>Erneut versuchen</button>
+          <a id="recovery-open" href="/?app-repair=manual">App jetzt öffnen</a>
+        </div>
+
+        <noscript>
+          <p class="recovery-noscript">
+            JavaScript ist deaktiviert. Bitte öffnen Sie über „App jetzt öffnen“ die aktuelle App.
+          </p>
+        </noscript>
+      </section>
+    </main>
+  </body>
+</html>

--- a/client/public/recover.js
+++ b/client/public/recover.js
@@ -1,0 +1,110 @@
+(() => {
+  'use strict';
+
+  const APP_CACHE_PREFIX = 'keeplocal-';
+  const APP_PREFERENCE_KEYS = ['theme', 'keeplocal_settings', 'token'];
+  const status = document.querySelector('.recovery-status');
+  const statusMark = document.getElementById('recovery-status-mark');
+  const statusTitle = document.getElementById('recovery-status-title');
+  const statusDetail = document.getElementById('recovery-status-detail');
+  const retryButton = document.getElementById('recovery-retry');
+  const openLink = document.getElementById('recovery-open');
+  let running = false;
+
+  function wait(milliseconds) {
+    return new Promise(resolve => window.setTimeout(resolve, milliseconds));
+  }
+
+  function setStatus(state, title, detail) {
+    if (status) status.className = `recovery-status${state ? ` ${state}` : ''}`;
+    if (statusMark) statusMark.textContent = state === 'is-complete' ? '✓' : state === 'is-error' ? '!' : '↻';
+    if (statusTitle) statusTitle.textContent = title;
+    if (statusDetail) statusDetail.textContent = detail;
+  }
+
+  async function unregisterWorkers() {
+    try {
+      const serviceWorker = navigator.serviceWorker;
+      if (!serviceWorker || typeof serviceWorker.getRegistrations !== 'function') return;
+      const registrations = await serviceWorker.getRegistrations();
+      await Promise.allSettled(
+        Array.from(registrations).map(registration => registration.unregister())
+      );
+    } catch {
+      // Continue with cache and preference cleanup when this API is blocked.
+    }
+  }
+
+  async function removeAppCaches() {
+    try {
+      const cacheStorage = window.caches;
+      if (!cacheStorage || typeof cacheStorage.keys !== 'function') return;
+      const cacheNames = await cacheStorage.keys();
+      await Promise.allSettled(
+        cacheNames
+          .filter(cacheName => typeof cacheName === 'string' && cacheName.startsWith(APP_CACHE_PREFIX))
+          .map(cacheName => cacheStorage.delete(cacheName))
+      );
+    } catch {
+      // A network reload can still recover when Cache Storage is blocked.
+    }
+  }
+
+  function removeAppPreferences() {
+    try {
+      const storage = window.localStorage;
+      if (!storage || typeof storage.removeItem !== 'function') return;
+      for (const key of APP_PREFERENCE_KEYS) {
+        try {
+          storage.removeItem(key);
+        } catch {
+          // Keep removing the remaining KeepLocal-only preferences.
+        }
+      }
+    } catch {
+      // The current app tolerates unavailable local storage after redirect.
+    }
+  }
+
+  function currentAppUrl() {
+    const nonce = Date.now().toString(36);
+    try {
+      const url = new URL('/', window.location.origin);
+      url.searchParams.set('app-repair', nonce);
+      return url.toString();
+    } catch {
+      return `/?app-repair=${nonce}`;
+    }
+  }
+
+  async function repair() {
+    if (running) return;
+    running = true;
+    retryButton.hidden = true;
+    setStatus('', 'Reparatur läuft …', 'Service Worker und KeepLocal-Cache werden geprüft.');
+
+    removeAppPreferences();
+    await Promise.race([
+      Promise.allSettled([unregisterWorkers(), removeAppCaches()]),
+      wait(4000)
+    ]);
+
+    const appUrl = currentAppUrl();
+    openLink.href = appUrl;
+    setStatus('is-complete', 'Aktualisierung abgeschlossen', 'Die aktuelle KeepLocal-Version wird geöffnet.');
+    await wait(450);
+
+    try {
+      window.location.replace(appUrl);
+    } catch {
+      running = false;
+      retryButton.hidden = false;
+      setStatus('is-error', 'Automatisches Öffnen wurde blockiert', 'Bitte wählen Sie „App jetzt öffnen“.');
+    }
+  }
+
+  if (typeof retryButton?.addEventListener === 'function') {
+    retryButton.addEventListener('click', repair);
+  }
+  repair();
+})();

--- a/client/public/service-worker.js
+++ b/client/public/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'keeplocal-v6';
+const CACHE_NAME = 'keeplocal-v7';
 const urlsToCache = [
   '/',
   '/index.html',
@@ -76,6 +76,13 @@ self.addEventListener('fetch', event => {
 
   // Uploaded note images are private data. Never persist them in Cache Storage.
   if (url.pathname.startsWith('/uploads/')) {
+    event.respondWith(fetch(event.request, { cache: 'no-store' }));
+    return;
+  }
+
+  // The standalone recovery path must always come from the network so it can
+  // repair a stale app shell or service worker without depending on React.
+  if (['/recover.html', '/recover.js', '/recover.css'].includes(url.pathname)) {
     event.respondWith(fetch(event.request, { cache: 'no-store' }));
     return;
   }

--- a/client/tests/recoveryPage.test.js
+++ b/client/tests/recoveryPage.test.js
@@ -1,0 +1,47 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const clientRoot = path.join(__dirname, '..');
+const html = fs.readFileSync(path.join(clientRoot, 'public/recover.html'), 'utf8');
+const script = fs.readFileSync(path.join(clientRoot, 'public/recover.js'), 'utf8');
+const styles = fs.readFileSync(path.join(clientRoot, 'public/recover.css'), 'utf8');
+const serviceWorker = fs.readFileSync(path.join(clientRoot, 'public/service-worker.js'), 'utf8');
+const vercel = JSON.parse(fs.readFileSync(path.join(clientRoot, 'vercel.json'), 'utf8'));
+
+test('standalone recovery remains usable without the React bundle', () => {
+  assert.match(html, /<script src="\/recover\.js" defer><\/script>/);
+  assert.match(html, /aria-live="polite"/);
+  assert.match(html, /Konto und Notizen bleiben erhalten/);
+  assert.match(html, /href="\/\?app-repair=manual"/);
+  assert.match(styles, /\.recovery-actions (?:button|a):focus-visible/);
+  assert.match(styles, /@media \(max-width: 480px\)/);
+  assert.match(styles, /@media \(prefers-reduced-motion: reduce\)/);
+});
+
+test('standalone recovery removes only KeepLocal browser state before redirecting', () => {
+  assert.match(script, /APP_CACHE_PREFIX = 'keeplocal-'/);
+  assert.match(script, /\['theme', 'keeplocal_settings', 'token'\]/);
+  assert.match(script, /getRegistrations\(\)/);
+  assert.match(script, /cacheName\.startsWith\(APP_CACHE_PREFIX\)/);
+  assert.match(script, /Promise\.race/);
+  assert.match(script, /window\.location\.replace\(appUrl\)/);
+  assert.doesNotMatch(script, /classList/);
+  assert.doesNotMatch(script, /document\.cookie|localStorage\.clear|indexedDB/);
+});
+
+test('recovery assets bypass service worker and edge caches', () => {
+  assert.match(serviceWorker, /CACHE_NAME\s*=\s*['"]keeplocal-v7['"]/);
+  assert.match(serviceWorker, /\['\/recover\.html', '\/recover\.js', '\/recover\.css'\]\.includes/);
+  assert.match(serviceWorker, /fetch\(event\.request, \{ cache: 'no-store' \}\)/);
+
+  for (const source of ['/recover.html', '/recover.js', '/recover.css']) {
+    const rule = vercel.headers.find(header => header.source === source);
+    assert.ok(rule, `${source} header rule is missing`);
+    assert.ok(
+      rule.headers.some(header => header.key === 'Cache-Control' && /no-store/.test(header.value)),
+      `${source} must be served without caching`
+    );
+  }
+});

--- a/client/tests/serviceWorkerCacheStrategy.test.js
+++ b/client/tests/serviceWorkerCacheStrategy.test.js
@@ -30,7 +30,7 @@ test('service worker uses network-first handling before generic cache lookup for
 
 test('service worker cache name is bumped so old app-shell caches are discarded', () => {
   assert.doesNotMatch(serviceWorker, /CACHE_NAME\s*=\s*['"]keeplocal-v1['"]/);
-  assert.match(serviceWorker, /CACHE_NAME\s*=\s*['"]keeplocal-v6['"]/);
+  assert.match(serviceWorker, /CACHE_NAME\s*=\s*['"]keeplocal-v7['"]/);
   assert.match(serviceWorker, /cacheName\.startsWith\(['"]keeplocal-['"]\)/);
 });
 

--- a/client/vercel.json
+++ b/client/vercel.json
@@ -57,6 +57,37 @@
       ]
     },
     {
+      "source": "/recover.html",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache, no-store, must-revalidate"
+        },
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, nofollow"
+        }
+      ]
+    },
+    {
+      "source": "/recover.js",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache, no-store, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/recover.css",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache, no-store, must-revalidate"
+        }
+      ]
+    },
+    {
       "source": "/api/:path*",
       "headers": [
         {


### PR DESCRIPTION
## Ursache

Die gemeldete Hilfezeile stammt eindeutig aus dem alten v5-Bundle. Ein bereits laufender, veralteter Browser-Tab kann durch ein neues Deployment nicht zuverlässig repariert werden.

## Änderung

- unabhängige statische `/recover.html` außerhalb von React
- meldet Service Worker ab und löscht ausschließlich `keeplocal-*` Browser-Caches
- entfernt nur lokale Anzeigeoptionen und den veralteten `token`-Eintrag
- Kontocookie, serverseitiges Konto und Notizen bleiben unberührt
- Recovery-Assets werden mit `no-store` ausgeliefert und vom Service Worker nie gecacht
- Service-Worker-Cache auf v7 erhöht

## Verifikation

- Client: 52/52 Tests
- ESLint und Vite-Produktionsbuild erfolgreich
- Desktop und 390×844 mit Chromium geprüft
- alter v5-Cache, aktiv kontrollierender Worker und blockierte Browser-APIs geprüft
- Recovery führt jeweils zur aktuellen Login-/Demo-Oberfläche ohne Boundary- oder Konsolenfehler